### PR TITLE
feat(project_cleanup): Implement dry run mode for cleanup function

### DIFF
--- a/modules/project_cleanup/README.md
+++ b/modules/project_cleanup/README.md
@@ -31,6 +31,7 @@ The following services must be enabled on the project housing the cleanup functi
 | clean\_up\_org\_level\_cai\_feeds | Clean up organization level Cloud Asset Inventory Feeds. | `bool` | `false` | no |
 | clean\_up\_org\_level\_scc\_notifications | Clean up organization level Security Command Center notifications. | `bool` | `false` | no |
 | clean\_up\_org\_level\_tag\_keys | Clean up organization level Tag Keys. | `bool` | `false` | no |
+| dry\_run | If true, the cleanup function will only log what it would delete without performing deletions. | `bool` | `true` | no |
 | function\_docker\_registry | Docker Registry to use for storing the function's Docker images. Allowed values are CONTAINER\_REGISTRY (default) and ARTIFACT\_REGISTRY. | `string` | `null` | no |
 | function\_timeout\_s | The amount of time in seconds allotted for the execution of the function. | `number` | `500` | no |
 | job\_schedule | Cleaner function run frequency, in cron syntax | `string` | `"*/5 * * * *"` | no |

--- a/modules/project_cleanup/function_source/README.md
+++ b/modules/project_cleanup/function_source/README.md
@@ -21,6 +21,7 @@ The following environment variables may be specified to configure the cleanup ut
 | `CLEAN_UP_CAI_FEEDS`| Clean up organization level Cloud Asset Inventory Feeds. | `bool` | n/a | yes |
 | `CLEAN_UP_SCC_NOTIFICATIONS` | Clean up organization level Security Command Center notifications. | `bool` | n/a | yes |
 | `CLEAN_UP_TAG_KEYS` | Clean up organization level Tag Keys. | `bool` | n/a | yes |
+| `DRY_RUN` | If `true`, the function will only log what it would delete without performing deletions. | `bool` | n/a | yes |
 | `MAX_PROJECT_AGE_HOURS` | The project age, in hours, at which point deletion should be considered | integer | n/a | yes |
 | `SCC_NOTIFICATIONS_PAGE_SIZE` | The maximum number of notification configs to return in the call to `ListNotificationConfigs` service. The minimun value is 1 and the maximum value is 1000. | `number` | n/a | yes |
 | `TARGET_BILLING_SINKS` | List of Billing Account Log Sinks names regex that will be deleted. Regex example: `.*/sinks/sk-c-logging-.*-billing-.*` | `list(string)` | n/a | no |

--- a/modules/project_cleanup/function_source/main.go
+++ b/modules/project_cleanup/function_source/main.go
@@ -67,6 +67,7 @@ const (
 	CleanUpBillingSinks           = "CLEAN_UP_BILLING_SINKS"
 	TargetBillingSinks            = "TARGET_BILLING_SINKS"
 	BillingSinksPageSize          = "BILLING_SINKS_PAGE_SIZE"
+	DryRunMode                    = "DRY_RUN"
 )
 
 var (
@@ -87,6 +88,7 @@ var (
 	cleanUpBillingSinks    = getBoolFromEnv(CleanUpBillingSinks)
 	billingSinksPageSize   = getIntFromEnv(BillingSinksPageSize)
 	targetBillingSinks     = getRegexListFromEnv(TargetBillingSinks)
+	isDryRun               = getBoolFromEnv(DryRunMode)
 )
 
 type PubSubMessage struct {
@@ -448,6 +450,10 @@ func invoke(ctx context.Context) {
 
 	removeLien := func(name string) {
 		logger.Printf("Try to remove lien [%s]", name)
+		if isDryRun {
+			logger.Printf("[DRY RUN] Would remove lien: %s", name)
+			return
+		}
 		_, err := cloudResourceManagerService.Liens.Delete(name).Context(ctx).Do()
 		if err != nil {
 			logger.Printf("Failed to remove lien [%s], error [%s]", name, err.Error())
@@ -504,6 +510,10 @@ func invoke(ctx context.Context) {
 			}
 			projectID := strings.Split(resp.PubsubTopic, "/")[1]
 			if checkIfNameIncluded(resp.Name, includedSCCNotfisList) && projectDeleteRequestedFilter(projectID) {
+				if isDryRun {
+					logger.Printf("[DRY RUN] Would delete SCC notification [%s]", resp.Name)
+					continue
+				}
 				delReq := &securitycenterpb.DeleteNotificationConfigRequest{
 					Name: resp.Name,
 				}
@@ -525,6 +535,10 @@ func invoke(ctx context.Context) {
 			return
 		}
 		for _, tagValue := range tagValuesList.TagValues {
+			if isDryRun {
+				logger.Printf("[DRY RUN] Would delete tagValue [%s] from TagKey [%s]", tagValue.Name, tagKey)
+				continue
+			}
 			_, err := tagValuesService.Delete(tagValue.Name).Context(ctx).Do()
 			if err != nil {
 				logger.Printf("Failed to delete tagValue from TagKey [%s], error [%s]", tagKey, err.Error())
@@ -543,6 +557,10 @@ func invoke(ctx context.Context) {
 		for _, tagKey := range tagKeysList.TagKeys {
 			if !checkIfTagKeyShortNameExcluded(tagKey.ShortName, excludedTagKeysList) && tagKeyAgeFilter(tagKey) {
 				removeTagValues(tagKey.Name)
+				if isDryRun {
+					logger.Printf("[DRY RUN] Would delete tagKey [%s] from organization [%s]", tagKey.Name, organization)
+					continue
+				}
 				_, err := tagKeyService.Delete(tagKey.Name).Context(ctx).Do()
 				if err != nil {
 					logger.Printf("Failed to delete tagKey from organization [%s], error [%s]", organization, err.Error())
@@ -567,6 +585,10 @@ func invoke(ctx context.Context) {
 		for _, feed := range resp.Feeds {
 			projectID := strings.Split(feed.FeedOutputConfig.GetPubsubDestination().Topic, "/")[1]
 			if checkIfNameIncluded(feed.Name, includedFeedsList) && projectDeleteRequestedFilter(projectID) {
+				if isDryRun {
+					logger.Printf("[DRY RUN] Would remove the feed [%s]", feed.Name)
+					continue
+				}
 				delReq := &assetpb.DeleteFeedRequest{
 					Name: feed.Name,
 				}
@@ -590,6 +612,10 @@ func invoke(ctx context.Context) {
 		}
 		for _, sink := range sinkList.Sinks {
 			if sink.Name != "_Required" && sink.Name != "_Default" && billingSinkAgeFilter(sink) && checkIfNameIncluded(sink.ResourceName, targetBillingSinks) {
+				if isDryRun {
+					logger.Printf("[DRY RUN] Would delete billing account log sink [%s] from billing account [%s]", sink.ResourceName, billing)
+					continue
+				}
 				_, err = billingSinkService.Delete(sink.ResourceName).Context(ctx).Do()
 				if err != nil {
 					logger.Printf("Failed to delete billing account log sink [%s] from billing account [%s], error [%s]", sink.ResourceName, billing, err.Error())
@@ -607,10 +633,18 @@ func invoke(ctx context.Context) {
 		}
 		for _, policy := range firewallPolicyList.Items {
 			for _, association := range policy.Associations {
+				if isDryRun {
+					logger.Printf("[DRY RUN] Would Remove Association for Firewall Policy [%s] from folder [%s]", association.Name, folder)
+					continue
+				}
 				_, err := firewallPoliciesService.RemoveAssociation(policy.Name).Name(association.Name).Context(ctx).Do()
 				if err != nil {
 					logger.Printf("Failed to Remove Association for Firewall Policies from folder [%s], error [%s]", folder, err.Error())
 				}
+			}
+			if isDryRun {
+				logger.Printf("[DRY RUN] Would delete Firewall Policy [%s] from folder [%s]", policy.Name, folder)
+				continue
 			}
 			_, err := firewallPoliciesService.Delete(policy.Name).Context(ctx).Do()
 			if err != nil {
@@ -620,6 +654,10 @@ func invoke(ctx context.Context) {
 	}
 
 	removeProjectById := func(projectId string) error {
+		if isDryRun {
+			logger.Printf("[DRY RUN] Would request deletion for project: %s", projectId)
+			return nil
+		}
 		_, err := cloudResourceManagerService.Projects.Delete(projectId).Context(ctx).Do()
 		return err
 	}
@@ -645,6 +683,11 @@ func invoke(ctx context.Context) {
 				fallthrough
 			case "RUNNING":
 				logger.Printf("Deleting cluster %s status: %s", cluster.Name, clusterStatus)
+				if isDryRun {
+					logger.Printf("[DRY RUN] Would delete cluster [%s] for project [%s]", cluster.Name, projectId)
+					pendingDeletion++
+					continue
+				}
 				reqDCR := &containerpb.DeleteClusterRequest{Name: fmt.Sprintf("projects/%s/locations/%s/clusters/%s", projectId, cluster.Location, cluster.Name)}
 				_, err := containerService.DeleteCluster(ctx, reqDCR)
 				if err != nil {
@@ -681,6 +724,10 @@ func invoke(ctx context.Context) {
 
 		for _, service := range listResponse.Services {
 			logger.Printf("Try to remove service: %s", service.ServiceName)
+			if isDryRun {
+				logger.Printf("[DRY RUN] Would delete service [%s] for project [%s]", service.ServiceName, projectId)
+				continue
+			}
 			_, err = endpointService.Services.Delete(service.ServiceName).Do()
 			if err != nil {
 				logger.Printf("Failed to delete service [%s] for [%s], error [%s]", service.ServiceName, projectId, err.Error())
@@ -704,7 +751,7 @@ func invoke(ctx context.Context) {
 		}
 		if err != nil {
 			logger.Printf("Failed to remove project [%s], error [%s]", projectId, err.Error())
-		} else {
+		} else if !isDryRun {
 			logger.Printf("Removed project [%s]", projectId)
 		}
 	}
@@ -754,6 +801,10 @@ func invoke(ctx context.Context) {
 		folderId := folder.Name
 		removeFirewallPolicies(folderId)
 		logger.Printf("Try to delete folder with id [%s]", folderId)
+		if isDryRun {
+			logger.Printf("[DRY RUN] Would delete folder [%s]", folderId)
+			return
+		}
 		_, err := folderService.Delete(folderId).Do()
 		if err != nil {
 			logger.Printf("Failed to delete folder [%s], error [%s]", folderId, err.Error())

--- a/modules/project_cleanup/main.tf
+++ b/modules/project_cleanup/main.tf
@@ -78,5 +78,6 @@ module "scheduled_project_cleaner" {
     CLEAN_UP_BILLING_SINKS            = var.clean_up_billing_sinks
     TARGET_BILLING_SINKS              = jsonencode(var.target_billing_sinks)
     BILLING_SINKS_PAGE_SIZE           = var.list_billing_sinks_page_size
+    DRY_RUN                           = var.dry_run
   }
 }

--- a/modules/project_cleanup/variables.tf
+++ b/modules/project_cleanup/variables.tf
@@ -154,3 +154,9 @@ variable "function_docker_registry" {
   default     = null
   description = "Docker Registry to use for storing the function's Docker images. Allowed values are CONTAINER_REGISTRY (default) and ARTIFACT_REGISTRY."
 }
+
+variable "dry_run" {
+  description = "If true, the cleanup function will only log what it would delete without performing deletions."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
Introduces a dry run capability to the project cleanup module to enhance safety and provide better operational visibility.

When dry run mode is enabled, the cleanup function will log all the destructive actions it would have performed without actually executing them. This allows operators to preview and validate the scope of a cleanup operation before any resources are deleted.

This is implemented by:
- Adding a `dry_run` boolean variable in the Terraform module (`variables.tf`).
- Passing this variable as a `DRY_RUN` environment variable to the Cloud Function (`main.tf`).
- Updating the Go function (`main.go`) to read the `DRY_RUN` variable and wrap all destructive API calls (e.g., DeleteProject, DeleteLien, DeleteCluster, DeleteFolder) in a conditional check.

In dry run mode, a `[DRY RUN]` prefix is added to the log messages for clarity, and functions that return an error now return `nil` to simulate a successful operation.