### PR TITLE
Feature/exclude folders from cleanup

### DIFF
--- a/modules/project_cleanup/README.md
+++ b/modules/project_cleanup/README.md
@@ -50,6 +50,8 @@ The following services must be enabled on the project housing the cleanup functi
 | target\_tag\_name | The name of a tag to filter GCP projects on for consideration by the cleanup utility (legacy, use `target_included_labels` map instead). | `string` | `""` | no |
 | target\_tag\_value | The value of a tag to filter GCP projects on for consideration by the cleanup utility (legacy, use `target_included_labels` map instead). | `string` | `""` | no |
 | topic\_name | Name of pubsub topic connecting the scheduled projects cleanup function | `string` | `"pubsub_scheduled_project_cleaner"` | no |
+| dry\_run | If set to true, the function will only log the actions it would take without performing any deletions. | `bool` | `true` | no |
+| target\_excluded\_folders | List of folder IDs (e.g., '1234567890') to exclude from the entire cleanup process. | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/modules/project_cleanup/README.md
+++ b/modules/project_cleanup/README.md
@@ -31,6 +31,7 @@ The following services must be enabled on the project housing the cleanup functi
 | clean\_up\_org\_level\_cai\_feeds | Clean up organization level Cloud Asset Inventory Feeds. | `bool` | `false` | no |
 | clean\_up\_org\_level\_scc\_notifications | Clean up organization level Security Command Center notifications. | `bool` | `false` | no |
 | clean\_up\_org\_level\_tag\_keys | Clean up organization level Tag Keys. | `bool` | `false` | no |
+| dry\_run | If set to true, the function will only log the actions it would take without performing any deletions. | `bool` | `true` | no |
 | function\_docker\_registry | Docker Registry to use for storing the function's Docker images. Allowed values are CONTAINER\_REGISTRY (default) and ARTIFACT\_REGISTRY. | `string` | `null` | no |
 | function\_timeout\_s | The amount of time in seconds allotted for the execution of the function. | `number` | `500` | no |
 | job\_schedule | Cleaner function run frequency, in cron syntax | `string` | `"*/5 * * * *"` | no |
@@ -41,6 +42,7 @@ The following services must be enabled on the project housing the cleanup functi
 | project\_id | The project ID to host the scheduled function in | `string` | n/a | yes |
 | region | The region the project is in (App Engine specific) | `string` | n/a | yes |
 | target\_billing\_sinks | List of Billing Account Log Sinks names regex that will be deleted. Regex example: `.*/sinks/sk-c-logging-.*-billing-.*` | `list(string)` | `[]` | no |
+| target\_excluded\_folders | List of folder IDs (e.g., '1234567890') to exclude from the entire cleanup process. | `list(string)` | `[]` | no |
 | target\_excluded\_labels | Map of project lablels that won't be deleted. | `map(string)` | `{}` | no |
 | target\_excluded\_tagkeys | List of organization Tag Key short names that won't be deleted. | `list(string)` | `[]` | no |
 | target\_folder\_id | Folder ID to delete all projects under. | `string` | `""` | no |
@@ -50,9 +52,6 @@ The following services must be enabled on the project housing the cleanup functi
 | target\_tag\_name | The name of a tag to filter GCP projects on for consideration by the cleanup utility (legacy, use `target_included_labels` map instead). | `string` | `""` | no |
 | target\_tag\_value | The value of a tag to filter GCP projects on for consideration by the cleanup utility (legacy, use `target_included_labels` map instead). | `string` | `""` | no |
 | topic\_name | Name of pubsub topic connecting the scheduled projects cleanup function | `string` | `"pubsub_scheduled_project_cleaner"` | no |
-| dry\_run | If set to true, the function will only log the actions it would take without performing any deletions. | `bool` | `true` | no |
-| target\_excluded\_folders | List of folder IDs (e.g., '1234567890') to exclude from the entire cleanup process. | `list(string)` | `[]` | no |
-
 ## Outputs
 
 | Name | Description |

--- a/modules/project_cleanup/function_source/README.md
+++ b/modules/project_cleanup/function_source/README.md
@@ -21,9 +21,11 @@ The following environment variables may be specified to configure the cleanup ut
 | `CLEAN_UP_CAI_FEEDS`| Clean up organization level Cloud Asset Inventory Feeds. | `bool` | n/a | yes |
 | `CLEAN_UP_SCC_NOTIFICATIONS` | Clean up organization level Security Command Center notifications. | `bool` | n/a | yes |
 | `CLEAN_UP_TAG_KEYS` | Clean up organization level Tag Keys. | `bool` | n/a | yes |
+| `DRY_RUN` | If set to "true", the function will only log the actions it would take without performing any deletions. | `bool` | "true" | yes |
 | `MAX_PROJECT_AGE_HOURS` | The project age, in hours, at which point deletion should be considered | integer | n/a | yes |
 | `SCC_NOTIFICATIONS_PAGE_SIZE` | The maximum number of notification configs to return in the call to `ListNotificationConfigs` service. The minimun value is 1 and the maximum value is 1000. | `number` | n/a | yes |
 | `TARGET_BILLING_SINKS` | List of Billing Account Log Sinks names regex that will be deleted. Regex example: `.*/sinks/sk-c-logging-.*-billing-.*` | `list(string)` | n/a | no |
+| `TARGET_EXCLUDED_FOLDERS` | A JSON-encoded list of folder IDs (e.g., ["1234567890"]) to exclude from the cleanup process. Projects and sub-folders within these folders will be ignored. | `string` | n/a | no |
 | `TARGET_EXCLUDED_LABELS` | Labels to match on for identifying projects to avoid deletion | string | n/a | no |
 | `TARGET_EXCLUDED_TAGKEYS` | List of organization Tag Key short names that won't be deleted. | `list(string)` | n/a | no |
 | `TARGET_FOLDER_ID` | Folder ID to delete projects under | string | n/a | yes |

--- a/modules/project_cleanup/function_source/main.go
+++ b/modules/project_cleanup/function_source/main.go
@@ -67,6 +67,7 @@ const (
 	CleanUpBillingSinks           = "CLEAN_UP_BILLING_SINKS"
 	TargetBillingSinks            = "TARGET_BILLING_SINKS"
 	BillingSinksPageSize          = "BILLING_SINKS_PAGE_SIZE"
+	TargetExcludedFolders         = "TARGET_EXCLUDED_FOLDERS"
 )
 
 var (
@@ -87,6 +88,7 @@ var (
 	cleanUpBillingSinks    = getBoolFromEnv(CleanUpBillingSinks)
 	billingSinksPageSize   = getIntFromEnv(BillingSinksPageSize)
 	targetBillingSinks     = getRegexListFromEnv(TargetBillingSinks)
+	excludedFoldersMap     = getListFromEnvAsMap(TargetExcludedFolders)
 )
 
 type PubSubMessage struct {
@@ -421,6 +423,26 @@ func getFirewallPoliciesServiceOrTerminateExecution(ctx context.Context, client 
 	}
 	logger.Println("Got Firewall Policies Service")
 	return computeService.FirewallPolicies
+}
+
+func getListFromEnvAsMap(envVariableName string) map[string]bool {
+	envVar := os.Getenv(envVariableName)
+	listAsMap := make(map[string]bool)
+	if envVar == "" {
+		logger.Printf("No values provided for %s.", envVariableName)
+		return listAsMap
+	}
+	var stringList []string
+	err := json.Unmarshal([]byte(envVar), &stringList)
+	if err != nil {
+		logger.Printf("Failed to get list from [%s] env variable, error [%s]", envVariableName, err.Error())
+		return listAsMap
+	}
+	for _, item := range stringList {
+		listAsMap["folders/"+item] = true
+	}
+	logger.Printf("Loaded %d excluded folders from %s.", len(listAsMap), envVariableName)
+	return listAsMap
 }
 
 func initializeGoogleClient(ctx context.Context) *http.Client {
@@ -764,6 +786,10 @@ func invoke(ctx context.Context) {
 
 	getSubFoldersAndRemoveProjectsFoldersRecursively := func(folder *cloudresourcemanager2.Folder, recursion FolderRecursion) {
 		folderId := folder.Name
+		if excludedFoldersMap[folderId] {
+			logger.Printf("Skipping folder [%s] as it is in the exclusion list.", folderId)
+			return
+		}
 		listFoldersRequest := folderService.List().Parent(folderId).ShowDeleted(false)
 		if err := listFoldersRequest.Pages(ctx, func(foldersResponse *cloudresourcemanager2.ListFoldersResponse) error {
 			for _, folder := range foldersResponse.Folders {

--- a/modules/project_cleanup/function_source/main.go
+++ b/modules/project_cleanup/function_source/main.go
@@ -67,6 +67,7 @@ const (
 	CleanUpBillingSinks           = "CLEAN_UP_BILLING_SINKS"
 	TargetBillingSinks            = "TARGET_BILLING_SINKS"
 	BillingSinksPageSize          = "BILLING_SINKS_PAGE_SIZE"
+	DryRunMode                    = "DRY_RUN"
 	TargetExcludedFolders         = "TARGET_EXCLUDED_FOLDERS"
 )
 
@@ -88,6 +89,7 @@ var (
 	cleanUpBillingSinks    = getBoolFromEnv(CleanUpBillingSinks)
 	billingSinksPageSize   = getIntFromEnv(BillingSinksPageSize)
 	targetBillingSinks     = getRegexListFromEnv(TargetBillingSinks)
+	isDryRun               = getBoolFromEnv(DryRunMode)
 	excludedFoldersMap     = getListFromEnvAsMap(TargetExcludedFolders)
 )
 
@@ -642,6 +644,10 @@ func invoke(ctx context.Context) {
 	}
 
 	removeProjectById := func(projectId string) error {
+		if isDryRun {
+			logger.Printf("[DRY RUN] Would request deletion for project: %s", projectId)
+			return nil
+		}
 		_, err := cloudResourceManagerService.Projects.Delete(projectId).Context(ctx).Do()
 		return err
 	}
@@ -776,6 +782,10 @@ func invoke(ctx context.Context) {
 		folderId := folder.Name
 		removeFirewallPolicies(folderId)
 		logger.Printf("Try to delete folder with id [%s]", folderId)
+		if dryRun {
+			logger.Printf("[DRY RUN] Would delete folder with ID: %s", folderId)
+			return
+		}
 		_, err := folderService.Delete(folderId).Do()
 		if err != nil {
 			logger.Printf("Failed to delete folder [%s], error [%s]", folderId, err.Error())

--- a/modules/project_cleanup/function_source/main.go
+++ b/modules/project_cleanup/function_source/main.go
@@ -782,7 +782,7 @@ func invoke(ctx context.Context) {
 		folderId := folder.Name
 		removeFirewallPolicies(folderId)
 		logger.Printf("Try to delete folder with id [%s]", folderId)
-		if dryRun {
+		if isDryRun {
 			logger.Printf("[DRY RUN] Would delete folder with ID: %s", folderId)
 			return
 		}

--- a/modules/project_cleanup/main.tf
+++ b/modules/project_cleanup/main.tf
@@ -78,5 +78,6 @@ module "scheduled_project_cleaner" {
     CLEAN_UP_BILLING_SINKS            = var.clean_up_billing_sinks
     TARGET_BILLING_SINKS              = jsonencode(var.target_billing_sinks)
     BILLING_SINKS_PAGE_SIZE           = var.list_billing_sinks_page_size
+    TARGET_EXCLUDED_FOLDERS           = jsonencode(var.target_excluded_folders)
   }
 }

--- a/modules/project_cleanup/main.tf
+++ b/modules/project_cleanup/main.tf
@@ -78,6 +78,7 @@ module "scheduled_project_cleaner" {
     CLEAN_UP_BILLING_SINKS            = var.clean_up_billing_sinks
     TARGET_BILLING_SINKS              = jsonencode(var.target_billing_sinks)
     BILLING_SINKS_PAGE_SIZE           = var.list_billing_sinks_page_size
+    DRY_RUN                           = var.dry_run
     TARGET_EXCLUDED_FOLDERS           = jsonencode(var.target_excluded_folders)
   }
 }

--- a/modules/project_cleanup/variables.tf
+++ b/modules/project_cleanup/variables.tf
@@ -162,7 +162,7 @@ variable "dry_run" {
 }
 variable "target_excluded_folders" {
   description = "List of folder IDs (e.g., '1234567890') to exclude from the entire cleanup process."
-  type        = list(string)
+  type        = set(string)
   default     = []
 }
 

--- a/modules/project_cleanup/variables.tf
+++ b/modules/project_cleanup/variables.tf
@@ -155,6 +155,11 @@ variable "function_docker_registry" {
   description = "Docker Registry to use for storing the function's Docker images. Allowed values are CONTAINER_REGISTRY (default) and ARTIFACT_REGISTRY."
 }
 
+variable "dry_run" {
+  description = "If set to true, the function will only log the actions it would take without performing any deletions."
+  type        = bool
+  default     = true
+}
 variable "target_excluded_folders" {
   description = "List of folder IDs (e.g., '1234567890') to exclude from the entire cleanup process."
   type        = list(string)

--- a/modules/project_cleanup/variables.tf
+++ b/modules/project_cleanup/variables.tf
@@ -154,3 +154,10 @@ variable "function_docker_registry" {
   default     = null
   description = "Docker Registry to use for storing the function's Docker images. Allowed values are CONTAINER_REGISTRY (default) and ARTIFACT_REGISTRY."
 }
+
+variable "target_excluded_folders" {
+  description = "List of folder IDs (e.g., '1234567890') to exclude from the entire cleanup process."
+  type        = list(string)
+  default     = []
+}
+


### PR DESCRIPTION
This PR enhances the project cleanup module with two key safety and control features:

Folder Exclusion: Adds a `target_excluded_folders` variable to prevent the function from processing specified folders and their contents. This is crucial for protecting sensitive environments from accidental cleanup.

Dry Run Mode: Introduces a `dry_run` mode, enabled by default, which logs all intended deletions without performing them. This allows for safe validation of the function's behavior before enabling destructive operations.
