### PR TITLE
feat(cleanup): Add Shared VPC (XPN) cleanup functionality

### DIFF
--- a/modules/project_cleanup/README.md
+++ b/modules/project_cleanup/README.md
@@ -1,6 +1,12 @@
 # Old Project Cleanup Utility Module
 
-This module schedules a job to clean up GCP projects older than a specified length of time, that match a particular labels. This job runs every 5 minutes via Google Cloud Scheduled Functions. Please see the [utility's readme](./function_source/README.md) for more information as to its operation and configuration.
+This module schedules a job to clean up GCP resources based on specific criteria, running every 5 minutes via Google Cloud Scheduled Functions. Its main capabilities include:
+
+* **Project Deletion:** Deletes GCP projects that are older than a specified age and match a particular set of labels.
+* **Organization-Level Cleanup:** Cleans up organization-level resources that are no longer in use, such as Tag Keys, Security Command Center notifications, and Cloud Asset Inventory feeds.
+* **Billing Sink Cleanup:** Removes Billing Account Log Sinks that match certain criteria.
+* **Shared VPC Cleanup:** Disables Shared VPC host and resource associations for projects before deletion.
+
 
 ## Requirements
 
@@ -31,6 +37,8 @@ The following services must be enabled on the project housing the cleanup functi
 | clean\_up\_org\_level\_cai\_feeds | Clean up organization level Cloud Asset Inventory Feeds. | `bool` | `false` | no |
 | clean\_up\_org\_level\_scc\_notifications | Clean up organization level Security Command Center notifications. | `bool` | `false` | no |
 | clean\_up\_org\_level\_tag\_keys | Clean up organization level Tag Keys. | `bool` | `false` | no |
+| clean\_up\_shared\_vpc | If true, the function will disable Shared VPC host and resource associations for projects before deletion. | `bool` | `false` | no |
+| dry\_run | If true, the cleanup function will only log what it would delete without performing deletions. | `bool` | `true` | no |
 | function\_docker\_registry | Docker Registry to use for storing the function's Docker images. Allowed values are CONTAINER\_REGISTRY (default) and ARTIFACT\_REGISTRY. | `string` | `null` | no |
 | function\_timeout\_s | The amount of time in seconds allotted for the execution of the function. | `number` | `500` | no |
 | job\_schedule | Cleaner function run frequency, in cron syntax | `string` | `"*/5 * * * *"` | no |

--- a/modules/project_cleanup/function_source/README.md
+++ b/modules/project_cleanup/function_source/README.md
@@ -1,13 +1,30 @@
 # Project Cleanup Utility
 
-This is a simple utility that scans a GCP organization for projects matching certain criteria, and enqueues such projects for deletion. Currently supported criteria are the combination of:
+This is a simple utility that scans a GCP organization for resources matching certain criteria and enqueues them for deletion.
 
-- **Age:** Only projects older than the configured age, in hours, will be marked for deletion.
-- **Key-Value Pair Include:** Only projects whose labels contain the provided key-value pair will be marked for deletion.
-- **Key-Value Pair Exclude:** Projects whose labels contain the provided key-value pair won't be marked for deletion.
-- **Folder ID:** Only projects under this Folder ID will be recursively marked for deletion.
+### Cleanup Capabilities
 
-Both of these criteria must be met for a project to be deleted.
+* **Project Deletion:**
+    A project is deleted if **all** of the following conditions are met:
+    * It is inside the folder specified by `TARGET_FOLDER_ID`.
+    * It is older than the `MAX_PROJECT_AGE_HOURS`.
+    * Its labels match at least one key-value pair in `TARGET_INCLUDED_LABELS` (if the map is not empty).
+    * Its labels do not match any key-value pair in `TARGET_EXCLUDED_LABELS`.
+
+* **Organization-Level Resource Cleanup:**
+    * **Tag Keys:** A Tag Key is deleted if it's not in the `TARGET_EXCLUDED_TAGKEYS` list and is older than `MAX_PROJECT_AGE_HOURS`. All associated Tag Values are deleted first.
+    * **SCC Notifications:** A Security Command Center notification config is deleted if its name matches a regex in `TARGET_INCLUDED_SCC_NOTIFICATIONS` and its associated Pub/Sub topic belongs to a project that is already marked for deletion.
+    * **Cloud Asset Inventory Feeds:** A CAI feed is deleted if its name matches a regex in `TARGET_INCLUDED_FEEDS` and its associated Pub/Sub topic belongs to a project that is already marked for deletion.
+
+* **Billing Sink Cleanup:**
+    A Billing Account Log Sink is deleted if **all** of the following conditions are met:
+    * It is older than the `MAX_PROJECT_AGE_HOURS`.
+    * Its name matches at least one regex in the `TARGET_BILLING_SINKS` list.
+    * It is not one of the default sinks (`_Required`, `_Default`).
+
+* **Shared VPC Cleanup:**
+    * If `CLEAN_UP_SHARED_VPC` is true, the function will disable Shared VPC host and resource associations for projects before attempting deletion.
+
 
 ## Environment Configuration
 
@@ -20,7 +37,9 @@ The following environment variables may be specified to configure the cleanup ut
 | `CLEAN_UP_BILLING_SINKS` | Clean up Billing Account Sinks. | `bool` | n/a | yes |
 | `CLEAN_UP_CAI_FEEDS`| Clean up organization level Cloud Asset Inventory Feeds. | `bool` | n/a | yes |
 | `CLEAN_UP_SCC_NOTIFICATIONS` | Clean up organization level Security Command Center notifications. | `bool` | n/a | yes |
+| `CLEAN_UP_SHARED_VPC` | If true, the function will disable Shared VPC host and resource associations for projects before deletion. | `bool` | `false` | yes |
 | `CLEAN_UP_TAG_KEYS` | Clean up organization level Tag Keys. | `bool` | n/a | yes |
+| `DRY_RUN` | If true, the cleanup function will only log what it would delete without performing deletions. | `bool` | `true` | yes |
 | `MAX_PROJECT_AGE_HOURS` | The project age, in hours, at which point deletion should be considered | integer | n/a | yes |
 | `SCC_NOTIFICATIONS_PAGE_SIZE` | The maximum number of notification configs to return in the call to `ListNotificationConfigs` service. The minimun value is 1 and the maximum value is 1000. | `number` | n/a | yes |
 | `TARGET_BILLING_SINKS` | List of Billing Account Log Sinks names regex that will be deleted. Regex example: `.*/sinks/sk-c-logging-.*-billing-.*` | `list(string)` | n/a | no |

--- a/modules/project_cleanup/function_source/main.go
+++ b/modules/project_cleanup/function_source/main.go
@@ -67,6 +67,8 @@ const (
 	CleanUpBillingSinks           = "CLEAN_UP_BILLING_SINKS"
 	TargetBillingSinks            = "TARGET_BILLING_SINKS"
 	BillingSinksPageSize          = "BILLING_SINKS_PAGE_SIZE"
+	DryRunMode                    = "DRY_RUN"
+	CleanUpSharedVPC              = "CLEAN_UP_SHARED_VPC"
 )
 
 var (
@@ -87,6 +89,8 @@ var (
 	cleanUpBillingSinks    = getBoolFromEnv(CleanUpBillingSinks)
 	billingSinksPageSize   = getIntFromEnv(BillingSinksPageSize)
 	targetBillingSinks     = getRegexListFromEnv(TargetBillingSinks)
+	isDryRun               = getBoolFromEnv(DryRunMode)
+	cleanUpSharedVPC       = getBoolFromEnv(CleanUpSharedVPC)
 )
 
 type PubSubMessage struct {
@@ -423,6 +427,16 @@ func getFirewallPoliciesServiceOrTerminateExecution(ctx context.Context, client 
 	return computeService.FirewallPolicies
 }
 
+func getComputeServiceOrTerminateExecution(ctx context.Context, client *http.Client) *compute.Service {
+	logger.Println("Try to get Compute Service")
+	computeService, err := compute.NewService(ctx, option.WithHTTPClient(client))
+	if err != nil {
+		logger.Fatalf("Failed to get Compute Service with error [%s], terminate execution", err.Error())
+	}
+	logger.Println("Got Compute Service")
+	return computeService
+}
+
 func initializeGoogleClient(ctx context.Context) *http.Client {
 	logger.Println("Try to initialize Google client")
 	client, err := google.DefaultClient(ctx, cloudresourcemanager.CloudPlatformScope)
@@ -445,6 +459,7 @@ func invoke(ctx context.Context) {
 	firewallPoliciesService := getFirewallPoliciesServiceOrTerminateExecution(ctx, client)
 	endpointService := getServiceManagementServiceOrTerminateExecution(ctx, client)
 	containerService := getContainerServiceOrTerminateExecution(ctx)
+	computeService := getComputeServiceOrTerminateExecution(ctx, client)
 
 	removeLien := func(name string) {
 		logger.Printf("Try to remove lien [%s]", name)
@@ -709,7 +724,52 @@ func invoke(ctx context.Context) {
 		}
 	}
 
+	cleanUpSharedVPC := func(projectId string) {
+		if !cleanUpSharedVPC {
+			return
+		}
+		logger.Printf("Checking for Shared VPC (XPN) resources in project [%s]", projectId)
+
+		xpnResources, err := computeService.Projects.GetXpnResources(projectId).Do()
+		if err != nil {
+			logger.Printf("Could not get XPN resources for project [%s] (may not be a host project): %v", projectId, err)
+		} else if xpnResources != nil && len(xpnResources.Resources) > 0 {
+			for _, resource := range xpnResources.Resources {
+				logger.Printf("Disabling XPN resource [%s] for project [%s]", resource.Id, projectId)
+				if isDryRun {
+					logger.Printf("[DRY RUN] Would disable XPN resource for service project [%s]", resource.Id)
+					continue
+				}
+				op, err := computeService.Projects.DisableXpnResource(projectId, &compute.ProjectsDisableXpnResourceRequest{
+					XpnResource: &compute.XpnResourceId{
+						Id:   resource.Id,
+						Type: "PROJECT",
+					},
+				}).Do()
+
+				if err != nil {
+					logger.Printf("Error disabling XPN resource for service project [%s]: %v", resource.Id, err)
+				} else {
+					logger.Printf("Successfully initiated disabling of XPN resource for service project [%s]. Operation: %s", resource.Id, op.Name)
+				}
+			}
+		}
+
+		logger.Printf("Disabling project [%s] as an XPN host", projectId)
+		if isDryRun {
+			logger.Printf("[DRY RUN] Would disable XPN host for project [%s]", projectId)
+			return
+		}
+		op, err := computeService.Projects.DisableXpnHost(projectId).Do()
+		if err != nil {
+			logger.Printf("Could not disable XPN host for project [%s] (may not be a host): %v", projectId, err)
+		} else {
+			logger.Printf("Successfully initiated disabling of XPN host for project [%s]. Operation: %s", projectId, op.Name)
+		}
+	}
+
 	removeProjectWithLiens := func(projectId string) {
+		cleanUpSharedVPC(projectId)
 		logger.Printf("Try to get all liens for the project [%s]", projectId)
 		parent := fmt.Sprintf("projects/%s", projectId)
 		req := cloudResourceManagerService.Liens.List().Parent(parent)

--- a/modules/project_cleanup/main.tf
+++ b/modules/project_cleanup/main.tf
@@ -78,5 +78,7 @@ module "scheduled_project_cleaner" {
     CLEAN_UP_BILLING_SINKS            = var.clean_up_billing_sinks
     TARGET_BILLING_SINKS              = jsonencode(var.target_billing_sinks)
     BILLING_SINKS_PAGE_SIZE           = var.list_billing_sinks_page_size
+    DRY_RUN                           = var.dry_run
+    CLEAN_UP_SHARED_VPC               = var.clean_up_shared_vpc
   }
 }

--- a/modules/project_cleanup/variables.tf
+++ b/modules/project_cleanup/variables.tf
@@ -154,3 +154,15 @@ variable "function_docker_registry" {
   default     = null
   description = "Docker Registry to use for storing the function's Docker images. Allowed values are CONTAINER_REGISTRY (default) and ARTIFACT_REGISTRY."
 }
+
+variable "dry_run" {
+  description = "If true, the cleanup function will only log what it would delete without performing deletions."
+  type        = bool
+  default     = true
+}
+
+variable "clean_up_shared_vpc" {
+  description = "If true, the function will disable Shared VPC host and resource associations for projects before deletion."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
This change introduces the capability to automatically handle Shared VPC deconfiguration before a project is deleted, preventing deletion failures caused by active XPN host or service project associations.

Key changes:
- Adds a `clean_up_shared_vpc` boolean variable to the Terraform module to enable/disable this feature.
- Implements a `cleanUpSharedVPC` function in `main.go` that:
  - Disables all associated service projects (XpnResources).
  - Disables the host project status (DisableXpnHost).
- Integrates this function into the project deletion lifecycle, calling it before attempting to remove liens and delete the project.
- The entire feature is covered by the `dryRun` mode for safe simulation.