### PR TITLE
Feature/cleanup stale access levels

### DIFF
--- a/modules/project_cleanup/README.md
+++ b/modules/project_cleanup/README.md
@@ -1,6 +1,13 @@
 # Old Project Cleanup Utility Module
 
-This module schedules a job to clean up GCP projects older than a specified length of time, that match a particular labels. This job runs every 5 minutes via Google Cloud Scheduled Functions. Please see the [utility's readme](./function_source/README.md) for more information as to its operation and configuration.
+This module schedules a job to clean up GCP resources based on specific criteria, running every 5 minutes via Google Cloud Scheduled Functions. Its main capabilities include:
+
+* **Project Deletion:** Deletes GCP projects that are older than a specified age and match a particular set of labels.
+* **Organization-Level Cleanup:** Cleans up organization-level resources that are no longer in use, such as Tag Keys, Security Command Center notifications, and Cloud Asset Inventory feeds.
+* **Billing Sink Cleanup:** Removes Billing Account Log Sinks that match certain criteria.
+* **Stale Access Level Cleanup:** Deletes Access Levels that are unused (not part of any Service Perimeter) or have no members.
+
+For more details on its operation and configuration, please see the [function's readme](./function_source/README.md).
 
 ## Requirements
 
@@ -20,19 +27,21 @@ The following services must be enabled on the project housing the cleanup functi
 - Cloud Asset API (`cloudasset.googleapis.com`)
 - Security Command Center API (`securitycenter.googleapis.com`)
 - Cloud Logging API (`logging.googleapis.com`)
+- Access Context Manager API (`accesscontextmanager.googleapis.com`)
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| access_policy_name           | The parent access policy from which Access Levels will be cleaned. Required if `clean_up_stale_access_levels` is true. | `string` | `""` | no |
+| access\_policy\_name | The name of the Access Policy to clean resources from. | `string` | `""` | no |
 | billing\_account | Billing Account used to provision resources. | `string` | `""` | no |
 | clean\_up\_billing\_sinks | Clean up Billing Account Sinks. | `bool` | `false` | no |
 | clean\_up\_org\_level\_cai\_feeds | Clean up organization level Cloud Asset Inventory Feeds. | `bool` | `false` | no |
 | clean\_up\_org\_level\_scc\_notifications | Clean up organization level Security Command Center notifications. | `bool` | `false` | no |
 | clean\_up\_org\_level\_tag\_keys | Clean up organization level Tag Keys. | `bool` | `false` | no |
 | clean_up_stale_access_levels | If true, the function will clean up stale Access Levels based on their configuration and usage. | `bool` | `false` | no |
+| dry\_run | If true, the cleanup function will only log what it would delete without performing deletions. | `bool` | `true` | no |
 | function\_docker\_registry | Docker Registry to use for storing the function's Docker images. Allowed values are CONTAINER\_REGISTRY (default) and ARTIFACT\_REGISTRY. | `string` | `null` | no |
 | function\_timeout\_s | The amount of time in seconds allotted for the execution of the function. | `number` | `500` | no |
 | job\_schedule | Cleaner function run frequency, in cron syntax | `string` | `"*/5 * * * *"` | no |

--- a/modules/project_cleanup/README.md
+++ b/modules/project_cleanup/README.md
@@ -26,11 +26,13 @@ The following services must be enabled on the project housing the cleanup functi
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| access_policy_name           | The parent access policy from which Access Levels will be cleaned. Required if `clean_up_stale_access_levels` is true. | `string` | `""` | no |
 | billing\_account | Billing Account used to provision resources. | `string` | `""` | no |
 | clean\_up\_billing\_sinks | Clean up Billing Account Sinks. | `bool` | `false` | no |
 | clean\_up\_org\_level\_cai\_feeds | Clean up organization level Cloud Asset Inventory Feeds. | `bool` | `false` | no |
 | clean\_up\_org\_level\_scc\_notifications | Clean up organization level Security Command Center notifications. | `bool` | `false` | no |
 | clean\_up\_org\_level\_tag\_keys | Clean up organization level Tag Keys. | `bool` | `false` | no |
+| clean_up_stale_access_levels | If true, the function will clean up stale Access Levels based on their configuration and usage. | `bool` | `false` | no |
 | function\_docker\_registry | Docker Registry to use for storing the function's Docker images. Allowed values are CONTAINER\_REGISTRY (default) and ARTIFACT\_REGISTRY. | `string` | `null` | no |
 | function\_timeout\_s | The amount of time in seconds allotted for the execution of the function. | `number` | `500` | no |
 | job\_schedule | Cleaner function run frequency, in cron syntax | `string` | `"*/5 * * * *"` | no |

--- a/modules/project_cleanup/function_source/README.md
+++ b/modules/project_cleanup/function_source/README.md
@@ -15,12 +15,14 @@ The following environment variables may be specified to configure the cleanup ut
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| `ACCESS_POLICY_NAME` | (Required if `CLEAN_UP_STALE_ACCESS_LEVELS` is true) The full name of the parent Access Policy to scan for stale levels . | `string` | n/a | no |
 | `BILLING_ACCOUNT` | Billing Account used to provision resources. | `string` | n/a | no |
 | `BILLING_SINKS_PAGE_SIZE ` | The maximum number of Billing Account Log Sinks to return in the call to `BillingAccountsSinksService.List` service. | `number` | n/a | yes |
 | `CLEAN_UP_BILLING_SINKS` | Clean up Billing Account Sinks. | `bool` | n/a | yes |
 | `CLEAN_UP_CAI_FEEDS`| Clean up organization level Cloud Asset Inventory Feeds. | `bool` | n/a | yes |
 | `CLEAN_UP_SCC_NOTIFICATIONS` | Clean up organization level Security Command Center notifications. | `bool` | n/a | yes |
 | `CLEAN_UP_TAG_KEYS` | Clean up organization level Tag Keys. | `bool` | n/a | yes |
+| `CLEAN_UP_STALE_ACCESS_LEVELS` | Clean up stale Access Levels based on their configuration and usage. | `bool` | n/a | no |
 | `MAX_PROJECT_AGE_HOURS` | The project age, in hours, at which point deletion should be considered | integer | n/a | yes |
 | `SCC_NOTIFICATIONS_PAGE_SIZE` | The maximum number of notification configs to return in the call to `ListNotificationConfigs` service. The minimun value is 1 and the maximum value is 1000. | `number` | n/a | yes |
 | `TARGET_BILLING_SINKS` | List of Billing Account Log Sinks names regex that will be deleted. Regex example: `.*/sinks/sk-c-logging-.*-billing-.*` | `list(string)` | n/a | no |

--- a/modules/project_cleanup/function_source/README.md
+++ b/modules/project_cleanup/function_source/README.md
@@ -1,13 +1,32 @@
 # Project Cleanup Utility
 
-This is a simple utility that scans a GCP organization for projects matching certain criteria, and enqueues such projects for deletion. Currently supported criteria are the combination of:
+This is a simple utility that scans a GCP organization for resources matching certain criteria and enqueues them for deletion.
 
-- **Age:** Only projects older than the configured age, in hours, will be marked for deletion.
-- **Key-Value Pair Include:** Only projects whose labels contain the provided key-value pair will be marked for deletion.
-- **Key-Value Pair Exclude:** Projects whose labels contain the provided key-value pair won't be marked for deletion.
-- **Folder ID:** Only projects under this Folder ID will be recursively marked for deletion.
+### Cleanup Capabilities
 
-Both of these criteria must be met for a project to be deleted.
+* **Project Deletion:**
+    A project is deleted if **all** of the following conditions are met:
+    * It is inside the folder specified by `TARGET_FOLDER_ID`.
+    * It is older than the `MAX_PROJECT_AGE_HOURS`.
+    * Its labels match at least one key-value pair in `TARGET_INCLUDED_LABELS` (if the map is not empty).
+    * Its labels do not match any key-value pair in `TARGET_EXCLUDED_LABELS`.
+
+* **Organization-Level Resource Cleanup:**
+    * **Tag Keys:** A Tag Key is deleted if it's not in the `TARGET_EXCLUDED_TAGKEYS` list and is older than `MAX_PROJECT_AGE_HOURS`. All associated Tag Values are deleted first.
+    * **SCC Notifications:** A Security Command Center notification config is deleted if its name matches a regex in `TARGET_INCLUDED_SCC_NOTIFICATIONS` and its associated Pub/Sub topic belongs to a project that is already marked for deletion.
+    * **Cloud Asset Inventory Feeds:** A CAI feed is deleted if its name matches a regex in `TARGET_INCLUDED_FEEDS` and its associated Pub/Sub topic belongs to a project that is already marked for deletion.
+
+* **Billing Sink Cleanup:**
+    A Billing Account Log Sink is deleted if **all** of the following conditions are met:
+    * It is older than the `MAX_PROJECT_AGE_HOURS`.
+    * Its name matches at least one regex in the `TARGET_BILLING_SINKS` list.
+    * It is not one of the default sinks (`_Required`, `_Default`).
+
+* **Stale Access Level Cleanup:**
+    An Access Level is deleted if it meets either of the following conditions:
+    * It is not in use by any Service Perimeter.
+    * It has no members defined in its conditions.
+
 
 ## Environment Configuration
 
@@ -15,26 +34,31 @@ The following environment variables may be specified to configure the cleanup ut
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| `ACCESS_POLICY_NAME` | (Required if `CLEAN_UP_STALE_ACCESS_LEVELS` is true) The full name of the parent Access Policy to scan for stale levels . | `string` | n/a | no |
+| `ACCESS_POLICY_NAME` | The name of the Access Policy to clean resources from. | `string` | n/a | no |
 | `BILLING_ACCOUNT` | Billing Account used to provision resources. | `string` | n/a | no |
 | `BILLING_SINKS_PAGE_SIZE ` | The maximum number of Billing Account Log Sinks to return in the call to `BillingAccountsSinksService.List` service. | `number` | n/a | yes |
 | `CLEAN_UP_BILLING_SINKS` | Clean up Billing Account Sinks. | `bool` | n/a | yes |
 | `CLEAN_UP_CAI_FEEDS`| Clean up organization level Cloud Asset Inventory Feeds. | `bool` | n/a | yes |
 | `CLEAN_UP_SCC_NOTIFICATIONS` | Clean up organization level Security Command Center notifications. | `bool` | n/a | yes |
-| `CLEAN_UP_TAG_KEYS` | Clean up organization level Tag Keys. | `bool` | n/a | yes |
 | `CLEAN_UP_STALE_ACCESS_LEVELS` | Clean up stale Access Levels based on their configuration and usage. | `bool` | n/a | no |
-| `MAX_PROJECT_AGE_HOURS` | The project age, in hours, at which point deletion should be considered | integer | n/a | yes |
+| `CLEAN_UP_TAG_KEYS` | Clean up organization level Tag Keys. | `bool` | n/a | yes |
+| `DRY_RUN` | If true, the cleanup function will only log what it would delete without performing deletions. | `bool` | `true` | yes |
+| `MAX_PROJECT_AGE_HOURS` | The project age, in hours, at which point deletion should be considered. | integer | n/a | yes |
 | `SCC_NOTIFICATIONS_PAGE_SIZE` | The maximum number of notification configs to return in the call to `ListNotificationConfigs` service. The minimun value is 1 and the maximum value is 1000. | `number` | n/a | yes |
 | `TARGET_BILLING_SINKS` | List of Billing Account Log Sinks names regex that will be deleted. Regex example: `.*/sinks/sk-c-logging-.*-billing-.*` | `list(string)` | n/a | no |
-| `TARGET_EXCLUDED_LABELS` | Labels to match on for identifying projects to avoid deletion | string | n/a | no |
+| `TARGET_EXCLUDED_LABELS` | Labels to match on for identifying projects to avoid deletion. | string | n/a | no |
 | `TARGET_EXCLUDED_TAGKEYS` | List of organization Tag Key short names that won't be deleted. | `list(string)` | n/a | no |
-| `TARGET_FOLDER_ID` | Folder ID to delete projects under | string | n/a | yes |
+| `TARGET_FOLDER_ID` | Folder ID to delete projects under. | string | n/a | yes |
 | `TARGET_INCLUDED_FEEDS` | List of organization level Cloud Asset Inventory feeds that should be deleted. Regex example: `.*/feeds/fd-cai-monitoring-.*` | `list(string)` | n/a | no |
-| `TARGET_INCLUDED_LABELS` | Labels to match on for identifying projects to delete | string | n/a | no |
+| `TARGET_INCLUDED_LABELS` | Labels to match on for identifying projects to delete. | string | n/a | no |
 | `TARGET_INCLUDED_SCC_NOTIFICATIONS` | List of organization Security Command Center notifications names regex that will be deleted. Regex example: `.*/notificationConfigs/scc-notify-.*` | `list(string)` | n/a | no |
-| `TARGET_ORGANIZATION_ID` | The organization ID whose projects to clean up | `string` | n/a | yes |
+| `TARGET_ORGANIZATION_ID` | The organization ID whose projects to clean up. | `string` | n/a | yes |
 
 ## Required Permissions
 
-This Cloud Function must be run as a Service Account with the `Organization Administrator` (`roles/resourcemanager.organizationAdmin`) role.
-If `CLEAN_UP_BILLING_SINKS` is enabled the Service Account running the Cloud Function needs role Logs Configuration Writer(`roles/logging.configWriter`) in the billing account `BILLING_ACCOUNT`.
+This Cloud Function must be run as a Service Account with the following roles:
+
+* `Organization Administrator` (`roles/resourcemanager.organizationAdmin`)
+* `Access Context Manager Editor` (`roles/accesscontextmanager.policyEditor`)
+
+If `CLEAN_UP_BILLING_SINKS` is enabled, the Service Account running the Cloud Function needs the `Logs Configuration Writer` (`roles/logging.configWriter`) role on the billing account specified in `BILLING_ACCOUNT`.

--- a/modules/project_cleanup/function_source/main.go
+++ b/modules/project_cleanup/function_source/main.go
@@ -35,6 +35,7 @@ import (
 	"cloud.google.com/go/securitycenter/apiv1/securitycenterpb"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
+	"google.golang.org/api/accesscontextmanager/v1"
 	"google.golang.org/api/cloudresourcemanager/v1"
 	cloudresourcemanager2 "google.golang.org/api/cloudresourcemanager/v2"
 	cloudresourcemanager3 "google.golang.org/api/cloudresourcemanager/v3"
@@ -67,26 +68,32 @@ const (
 	CleanUpBillingSinks           = "CLEAN_UP_BILLING_SINKS"
 	TargetBillingSinks            = "TARGET_BILLING_SINKS"
 	BillingSinksPageSize          = "BILLING_SINKS_PAGE_SIZE"
+	DryRunMode                    = "DRY_RUN"
+	CleanUpStaleAccessLevels      = "CLEAN_UP_STALE_ACCESS_LEVELS"
+	AccessPolicyName              = "ACCESS_POLICY_NAME"
 )
 
 var (
-	logger                 = log.New(os.Stdout, "", 0)
-	excludedLabelsMap      = getLabelsMapFromEnv(TargetExcludedLabels)
-	includedLabelsMap      = getLabelsMapFromEnv(TargetIncludedLabels)
-	cleanUpTagKeys         = getBoolFromEnv(CleanUpTagKeys)
-	cleanUpSCCNotfi        = getBoolFromEnv(CleanUpSCCNotfi)
-	excludedTagKeysList    = getTagKeysListFromEnv(TargetExcludedTagKeys)
-	includedSCCNotfisList  = getRegexListFromEnv(TargetIncludedSCCNotfis)
-	resourceCreationCutoff = getOldTime(getIntFromEnv(MaxProjectAgeHours) * 60 * 60)
-	rootFolderId           = getCorrectFolderIdOrTerminateExecution()
-	organizationId         = getCorrectOrganizationIdOrTerminateExecution()
-	sccPageSize            = int32(getIntFromEnv(SCCNotificationsPageSize))
-	cleanUpCaiFeeds        = getBoolFromEnv(CleanUpCaiFeeds)
-	includedFeedsList      = getRegexListFromEnv(TargetIncludedFeeds)
-	billingAccount         = getBillingAccountOrTerminateExecution()
-	cleanUpBillingSinks    = getBoolFromEnv(CleanUpBillingSinks)
-	billingSinksPageSize   = getIntFromEnv(BillingSinksPageSize)
-	targetBillingSinks     = getRegexListFromEnv(TargetBillingSinks)
+	logger                   = log.New(os.Stdout, "", 0)
+	excludedLabelsMap        = getLabelsMapFromEnv(TargetExcludedLabels)
+	includedLabelsMap        = getLabelsMapFromEnv(TargetIncludedLabels)
+	cleanUpTagKeys           = getBoolFromEnv(CleanUpTagKeys)
+	cleanUpSCCNotfi          = getBoolFromEnv(CleanUpSCCNotfi)
+	excludedTagKeysList      = getTagKeysListFromEnv(TargetExcludedTagKeys)
+	includedSCCNotfisList    = getRegexListFromEnv(TargetIncludedSCCNotfis)
+	resourceCreationCutoff   = getOldTime(getIntFromEnv(MaxProjectAgeHours) * 60 * 60)
+	rootFolderId             = getCorrectFolderIdOrTerminateExecution()
+	organizationId           = getCorrectOrganizationIdOrTerminateExecution()
+	sccPageSize              = int32(getIntFromEnv(SCCNotificationsPageSize))
+	cleanUpCaiFeeds          = getBoolFromEnv(CleanUpCaiFeeds)
+	includedFeedsList        = getRegexListFromEnv(TargetIncludedFeeds)
+	billingAccount           = getBillingAccountOrTerminateExecution()
+	cleanUpBillingSinks      = getBoolFromEnv(CleanUpBillingSinks)
+	billingSinksPageSize     = getIntFromEnv(BillingSinksPageSize)
+	targetBillingSinks       = getRegexListFromEnv(TargetBillingSinks)
+	isDryRun                 = getBoolFromEnv(DryRunMode)
+	cleanUpStaleAccessLevels = getBoolFromEnv(CleanUpStaleAccessLevels)
+	accessPolicyName         = getAccessPolicyNameOrTerminateExecution()
 )
 
 type PubSubMessage struct {
@@ -423,6 +430,27 @@ func getFirewallPoliciesServiceOrTerminateExecution(ctx context.Context, client 
 	return computeService.FirewallPolicies
 }
 
+func getAccessPolicyNameOrTerminateExecution() string {
+	if !getBoolFromEnv(CleanUpStaleAccessLevels) {
+		return ""
+	}
+	policyName := os.Getenv(AccessPolicyName)
+	if policyName == "" {
+		logger.Fatalf("If Access Level cleanup is enabled, Access Policy Name variable [%s] must be set.", AccessPolicyName)
+	}
+	return policyName
+}
+
+func getAccessContextManagerServiceOrTerminateExecution(ctx context.Context, client *http.Client) *accesscontextmanager.Service {
+	logger.Println("Try to get Access Context Manager Service")
+	service, err := accesscontextmanager.NewService(ctx, option.WithHTTPClient(client))
+	if err != nil {
+		logger.Fatalf("Failed to get Access Context Manager Service with error [%s], terminate execution", err.Error())
+	}
+	logger.Println("Got Access Context Manager Service")
+	return service
+}
+
 func initializeGoogleClient(ctx context.Context) *http.Client {
 	logger.Println("Try to initialize Google client")
 	client, err := google.DefaultClient(ctx, cloudresourcemanager.CloudPlatformScope)
@@ -445,6 +473,7 @@ func invoke(ctx context.Context) {
 	firewallPoliciesService := getFirewallPoliciesServiceOrTerminateExecution(ctx, client)
 	endpointService := getServiceManagementServiceOrTerminateExecution(ctx, client)
 	containerService := getContainerServiceOrTerminateExecution(ctx)
+	accessContextManagerService := getAccessContextManagerServiceOrTerminateExecution(ctx, client)
 
 	removeLien := func(name string) {
 		logger.Printf("Try to remove lien [%s]", name)
@@ -779,6 +808,84 @@ func invoke(ctx context.Context) {
 		}
 	}
 
+	cleanStaleAccessLevels := func() {
+		logger.Println("Starting cleanup of stale Access Levels")
+		perimetersResponse, err := accessContextManagerService.AccessPolicies.ServicePerimeters.List(accessPolicyName).Do()
+		if err != nil {
+			logger.Printf("Failed to list Service Perimeters for stale access level check: %v", err)
+			return
+		}
+
+		accessLevelsResponse, err := accessContextManagerService.AccessPolicies.AccessLevels.List(accessPolicyName).Do()
+		if err != nil {
+			logger.Printf("Failed to list Access Levels: %v", err)
+			return
+		}
+
+		for _, level := range accessLevelsResponse.AccessLevels {
+			hasNoMembers := false
+			if level.Basic != nil {
+				if len(level.Basic.Conditions) == 0 {
+					hasNoMembers = true
+				} else {
+					allConditionsEmpty := true
+					for _, condition := range level.Basic.Conditions {
+						if len(condition.Members) > 0 {
+							allConditionsEmpty = false
+							break
+						}
+					}
+					hasNoMembers = allConditionsEmpty
+				}
+			}
+
+			isNotInUse := true
+			for _, perimeter := range perimetersResponse.ServicePerimeters {
+				if perimeter.Status != nil {
+					for _, levelName := range perimeter.Status.AccessLevels {
+						if levelName == level.Name {
+							isNotInUse = false
+							break
+						}
+					}
+				}
+				if !isNotInUse {
+					break
+				}
+				if perimeter.Spec != nil {
+					for _, levelName := range perimeter.Spec.AccessLevels {
+						if levelName == level.Name {
+							isNotInUse = false
+							break
+						}
+					}
+				}
+				if !isNotInUse {
+					break
+				}
+			}
+
+			if hasNoMembers || isNotInUse {
+				logReason := "it has no members"
+				if isNotInUse {
+					logReason = "it is not in use by any Service Perimeter"
+				}
+				logger.Printf("Access Level [%s] is stale because %s. Scheduling for deletion.", level.Name, logReason)
+
+				if isDryRun {
+					logger.Printf("[DRY RUN] Would delete Access Level [%s]", level.Name)
+					continue
+				}
+				_, err := accessContextManagerService.AccessPolicies.AccessLevels.Delete(level.Name).Do()
+				if err != nil {
+					logger.Printf("Error deleting Access Level [%s]: %v", level.Name, err)
+				} else {
+					logger.Printf("Successfully deleted Access Level [%s]", level.Name)
+				}
+			}
+		}
+	}
+
 	rootFolderId := fmt.Sprintf("folders/%s", rootFolderId)
 	rootFolder, err := folderService.Get(rootFolderId).Do()
 	if err != nil {
@@ -804,6 +911,10 @@ func invoke(ctx context.Context) {
 
 	if cleanUpBillingSinks {
 		removeBillingSinks(billingAccount)
+	}
+
+	if cleanUpStaleAccessLevels {
+		cleanStaleAccessLevels()
 	}
 }
 

--- a/modules/project_cleanup/main.tf
+++ b/modules/project_cleanup/main.tf
@@ -78,5 +78,8 @@ module "scheduled_project_cleaner" {
     CLEAN_UP_BILLING_SINKS            = var.clean_up_billing_sinks
     TARGET_BILLING_SINKS              = jsonencode(var.target_billing_sinks)
     BILLING_SINKS_PAGE_SIZE           = var.list_billing_sinks_page_size
+    DRY_RUN                           = var.dry_run
+    CLEAN_UP_STALE_ACCESS_LEVELS      = var.clean_up_stale_access_levels
+    ACCESS_POLICY_NAME                = var.access_policy_name
   }
 }

--- a/modules/project_cleanup/main.tf
+++ b/modules/project_cleanup/main.tf
@@ -37,6 +37,7 @@ resource "google_organization_iam_member" "main" {
     "roles/cloudasset.owner",
     "roles/securitycenter.notificationConfigEditor",
     "roles/logging.configWriter",
+    "roles/accesscontextmanager.policyEditor",
   ])
 
   member = "serviceAccount:${google_service_account.project_cleaner_function.email}"

--- a/modules/project_cleanup/variables.tf
+++ b/modules/project_cleanup/variables.tf
@@ -154,3 +154,21 @@ variable "function_docker_registry" {
   default     = null
   description = "Docker Registry to use for storing the function's Docker images. Allowed values are CONTAINER_REGISTRY (default) and ARTIFACT_REGISTRY."
 }
+
+variable "dry_run" {
+  description = "If true, the cleanup function will only log what it would delete without performing deletions."
+  type        = bool
+  default     = true
+}
+
+variable "clean_up_stale_access_levels" {
+  description = "If true, the function will clean up stale Access Levels that are unused or have no members."
+  type        = bool
+  default     = false
+}
+
+variable "access_policy_name" {
+  description = "The name of the Access Policy to clean resources from, in the format 'accessPolicies/123456789'."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
feat(cleanup): Add stale Access Level cleanup functionality
Transcribes and integrates the cleanup logic for stale Access Levels from the Python script to the Go module.

This feature helps maintain security hygiene by removing unused Access Context Manager Access Levels based on two conditions:
1. The Access Level has no 'members' defined in any of its conditions.
2. The Access Level is not referenced by any Service Perimeter in either its enforced (status) or dry-run (spec) configuration.

Key changes:
- Adds `clean_up_stale_access_levels` and `access_policy_name` variables to the Terraform module.
- Implements the `cleanStaleAccessLevels` function in `main.go`.
- Integrates the function into the main `invoke` lifecycle.
- All delete operations are covered by the `dryRun` mode.