### PR TITLE
feat(cleanup): Add empty Service Perimeter cleanup functionality

### DIFF
--- a/modules/project_cleanup/README.md
+++ b/modules/project_cleanup/README.md
@@ -36,7 +36,7 @@ The following services must be enabled on the project housing the cleanup functi
 | job\_schedule | Cleaner function run frequency, in cron syntax | `string` | `"*/5 * * * *"` | no |
 | list\_billing\_sinks\_page\_size | The maximum number of Billing Account Log Sinks to return in the call to `BillingAccountsSinksService.List` service. | `number` | `200` | no |
 | list\_scc\_notifications\_page\_size | The maximum number of notification configs to return in the call to `ListNotificationConfigs` service. The minimun value is 1 and the maximum value is 1000. | `number` | `500` | no |
-| max\_project\_age\_in\_hours | The maximum number of hours that a GCP project, selected by `target_tag_name` and `target_tag_value`, can exist | `number` | `6` | no |
+| max\_resource\_age\_in\_hours | The maximum age in hours that a resource (e.g., project, folder, perimeter) can exist before being considered for cleanup. | `number` | `6` | no |
 | organization\_id | The organization ID whose projects to clean up | `string` | n/a | yes |
 | project\_id | The project ID to host the scheduled function in | `string` | n/a | yes |
 | region | The region the project is in (App Engine specific) | `string` | n/a | yes |

--- a/modules/project_cleanup/README.md
+++ b/modules/project_cleanup/README.md
@@ -1,6 +1,13 @@
 # Old Project Cleanup Utility Module
 
-This module schedules a job to clean up GCP projects older than a specified length of time, that match a particular labels. This job runs every 5 minutes via Google Cloud Scheduled Functions. Please see the [utility's readme](./function_source/README.md) for more information as to its operation and configuration.
+This module schedules a job to clean up GCP resources based on specific criteria, running every 5 minutes via Google Cloud Scheduled Functions. Its main capabilities include:
+
+* **Project Deletion:** Deletes GCP projects that are older than a specified age and match a particular set of labels.
+* **Organization-Level Cleanup:** Cleans up organization-level resources that are no longer in use, such as Tag Keys, Security Command Center notifications, and Cloud Asset Inventory feeds.
+* **Billing Sink Cleanup:** Removes Billing Account Log Sinks that match certain criteria.
+* **Empty Service Perimeter Cleanup:** Deletes Service Perimeters that are empty, obsolete, and marked with a specific flag for cleanup.
+
+For more details on its operation and configuration, please see the [function's readme](./function_source/README.md).
 
 ## Requirements
 
@@ -20,17 +27,21 @@ The following services must be enabled on the project housing the cleanup functi
 - Cloud Asset API (`cloudasset.googleapis.com`)
 - Security Command Center API (`securitycenter.googleapis.com`)
 - Cloud Logging API (`logging.googleapis.com`)
+- Access Context Manager API (`accesscontextmanager.googleapis.com`)
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| access\_policy\_name | The name of the Access Policy to clean resources from. | `string` | `""` | no |
 | billing\_account | Billing Account used to provision resources. | `string` | `""` | no |
 | clean\_up\_billing\_sinks | Clean up Billing Account Sinks. | `bool` | `false` | no |
+| clean\_up\_empty\_perimeters | If true, the function will clean up empty or obsolete Service Perimeters. | `bool` | `false` | no |
 | clean\_up\_org\_level\_cai\_feeds | Clean up organization level Cloud Asset Inventory Feeds. | `bool` | `false` | no |
 | clean\_up\_org\_level\_scc\_notifications | Clean up organization level Security Command Center notifications. | `bool` | `false` | no |
 | clean\_up\_org\_level\_tag\_keys | Clean up organization level Tag Keys. | `bool` | `false` | no |
+| dry\_run | If true, the cleanup function will only log what it would delete without performing deletions. | `bool` | `true` | no |
 | function\_docker\_registry | Docker Registry to use for storing the function's Docker images. Allowed values are CONTAINER\_REGISTRY (default) and ARTIFACT\_REGISTRY. | `string` | `null` | no |
 | function\_timeout\_s | The amount of time in seconds allotted for the execution of the function. | `number` | `500` | no |
 | job\_schedule | Cleaner function run frequency, in cron syntax | `string` | `"*/5 * * * *"` | no |
@@ -38,6 +49,7 @@ The following services must be enabled on the project housing the cleanup functi
 | list\_scc\_notifications\_page\_size | The maximum number of notification configs to return in the call to `ListNotificationConfigs` service. The minimun value is 1 and the maximum value is 1000. | `number` | `500` | no |
 | max\_resource\_age\_in\_hours | The maximum age in hours that a resource (e.g., project, folder, perimeter) can exist before being considered for cleanup. | `number` | `6` | no |
 | organization\_id | The organization ID whose projects to clean up | `string` | n/a | yes |
+| perimeter\_cleanup\_flags | A list of string flags used to identify test perimeters for cleanup. The function will look for these flags in the perimeter's description field. | `list(string)` | `[]` | no |
 | project\_id | The project ID to host the scheduled function in | `string` | n/a | yes |
 | region | The region the project is in (App Engine specific) | `string` | n/a | yes |
 | target\_billing\_sinks | List of Billing Account Log Sinks names regex that will be deleted. Regex example: `.*/sinks/sk-c-logging-.*-billing-.*` | `list(string)` | `[]` | no |

--- a/modules/project_cleanup/function_source/README.md
+++ b/modules/project_cleanup/function_source/README.md
@@ -1,13 +1,33 @@
 # Project Cleanup Utility
 
-This is a simple utility that scans a GCP organization for projects matching certain criteria, and enqueues such projects for deletion. Currently supported criteria are the combination of:
+This is a simple utility that scans a GCP organization for resources matching certain criteria and enqueues them for deletion.
 
-- **Age:** Only projects older than the configured age, in hours, will be marked for deletion.
-- **Key-Value Pair Include:** Only projects whose labels contain the provided key-value pair will be marked for deletion.
-- **Key-Value Pair Exclude:** Projects whose labels contain the provided key-value pair won't be marked for deletion.
-- **Folder ID:** Only projects under this Folder ID will be recursively marked for deletion.
+### Cleanup Capabilities
 
-Both of these criteria must be met for a project to be deleted.
+* **Project Deletion:**
+    A project is deleted if **all** of the following conditions are met:
+    * It is inside the folder specified by `TARGET_FOLDER_ID`.
+    * It is older than the `MAX_RESOURCE_AGE_HOURS`.
+    * Its labels match at least one key-value pair in `TARGET_INCLUDED_LABELS` (if the map is not empty).
+    * Its labels do not match any key-value pair in `TARGET_EXCLUDED_LABELS`.
+
+* **Organization-Level Resource Cleanup:**
+    * **Tag Keys:** A Tag Key is deleted if it's not in the `TARGET_EXCLUDED_TAGKEYS` list and is older than `MAX_RESOURCE_AGE_HOURS`. All associated Tag Values are deleted first.
+    * **SCC Notifications:** A Security Command Center notification config is deleted if its name matches a regex in `TARGET_INCLUDED_SCC_NOTIFICATIONS` and its associated Pub/Sub topic belongs to a project that is already marked for deletion.
+    * **Cloud Asset Inventory Feeds:** A CAI feed is deleted if its name matches a regex in `TARGET_INCLUDED_FEEDS` and its associated Pub/Sub topic belongs to a project that is already marked for deletion.
+
+* **Billing Sink Cleanup:**
+    A Billing Account Log Sink is deleted if **all** of the following conditions are met:
+    * It is older than the `MAX_RESOURCE_AGE_HOURS`.
+    * Its name matches at least one regex in the `TARGET_BILLING_SINKS` list.
+    * It is not one of the default sinks (`_Required`, `_Default`).
+
+* **Empty Service Perimeter Cleanup:**
+    A Service Perimeter is deleted if **all** of the following conditions are met:
+    * It is older than `MAX_RESOURCE_AGE_HOURS`.
+    * Its description starts with one of the flags defined in `PERIMETER_CLEANUP_FLAGS`, followed by an underscore (`_`) and a timestamp. The timestamp must be in **RFC3339 format** (e.g., `example-flag_2025-10-06T10:00:00Z`).
+    * The perimeter is considered empty, meaning its `spec` and `status` fields either have no resources/access levels defined, or the projects listed as resources no longer exist.
+
 
 ## Environment Configuration
 
@@ -15,24 +35,32 @@ The following environment variables may be specified to configure the cleanup ut
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| `ACCESS_POLICY_NAME` | The name of the Access Policy to clean resources from. | `string` | n/a | Yes, if `CLEAN_UP_EMPTY_PERIMETERS` is `true`. |
 | `BILLING_ACCOUNT` | Billing Account used to provision resources. | `string` | n/a | no |
 | `BILLING_SINKS_PAGE_SIZE ` | The maximum number of Billing Account Log Sinks to return in the call to `BillingAccountsSinksService.List` service. | `number` | n/a | yes |
 | `CLEAN_UP_BILLING_SINKS` | Clean up Billing Account Sinks. | `bool` | n/a | yes |
 | `CLEAN_UP_CAI_FEEDS`| Clean up organization level Cloud Asset Inventory Feeds. | `bool` | n/a | yes |
+| `CLEAN_UP_EMPTY_PERIMETERS` | If true, the function will clean up empty or obsolete Service Perimeters. | `bool` | `false` | yes |
 | `CLEAN_UP_SCC_NOTIFICATIONS` | Clean up organization level Security Command Center notifications. | `bool` | n/a | yes |
 | `CLEAN_UP_TAG_KEYS` | Clean up organization level Tag Keys. | `bool` | n/a | yes |
-| `MAX_RESOURCE_AGE_HOURS` | 	The resource age, in hours, at which point deletion should be considered | integer | n/a | yes |
+| `DRY_RUN` | If true, the cleanup function will only log what it would delete without performing deletions. | `bool` | `true` | yes |
+| `MAX_RESOURCE_AGE_HOURS` | 	The resource age, in hours, at which point deletion should be considered. | integer | n/a | yes |
+| `PERIMETER_CLEANUP_FLAGS` | A list of string flags used to identify test perimeters for cleanup. | `list(string)` | `[]` | no |
 | `SCC_NOTIFICATIONS_PAGE_SIZE` | The maximum number of notification configs to return in the call to `ListNotificationConfigs` service. The minimun value is 1 and the maximum value is 1000. | `number` | n/a | yes |
 | `TARGET_BILLING_SINKS` | List of Billing Account Log Sinks names regex that will be deleted. Regex example: `.*/sinks/sk-c-logging-.*-billing-.*` | `list(string)` | n/a | no |
-| `TARGET_EXCLUDED_LABELS` | Labels to match on for identifying projects to avoid deletion | string | n/a | no |
+| `TARGET_EXCLUDED_LABELS` | Labels to match on for identifying projects to avoid deletion. | string | n/a | no |
 | `TARGET_EXCLUDED_TAGKEYS` | List of organization Tag Key short names that won't be deleted. | `list(string)` | n/a | no |
-| `TARGET_FOLDER_ID` | Folder ID to delete projects under | string | n/a | yes |
+| `TARGET_FOLDER_ID` | Folder ID to delete projects under. | string | n/a | yes |
 | `TARGET_INCLUDED_FEEDS` | List of organization level Cloud Asset Inventory feeds that should be deleted. Regex example: `.*/feeds/fd-cai-monitoring-.*` | `list(string)` | n/a | no |
-| `TARGET_INCLUDED_LABELS` | Labels to match on for identifying projects to delete | string | n/a | no |
+| `TARGET_INCLUDED_LABELS` | Labels to match on for identifying projects to delete. | string | n/a | no |
 | `TARGET_INCLUDED_SCC_NOTIFICATIONS` | List of organization Security Command Center notifications names regex that will be deleted. Regex example: `.*/notificationConfigs/scc-notify-.*` | `list(string)` | n/a | no |
-| `TARGET_ORGANIZATION_ID` | The organization ID whose projects to clean up | `string` | n/a | yes |
+| `TARGET_ORGANIZATION_ID` | The organization ID whose projects to clean up. | `string` | n/a | yes |
 
 ## Required Permissions
 
-This Cloud Function must be run as a Service Account with the `Organization Administrator` (`roles/resourcemanager.organizationAdmin`) role.
-If `CLEAN_UP_BILLING_SINKS` is enabled the Service Account running the Cloud Function needs role Logs Configuration Writer(`roles/logging.configWriter`) in the billing account `BILLING_ACCOUNT`.
+This Cloud Function must be run as a Service Account with the following roles:
+
+-   `Organization Administrator` (`roles/resourcemanager.organizationAdmin`)
+-   `Access Context Manager Editor` (`roles/accesscontextmanager.policyEditor`)
+
+If `CLEAN_UP_BILLING_SINKS` is enabled the Service Account running the Cloud Function needs role `Logs Configuration Writer` (`roles/logging.configWriter`) in the billing account `BILLING_ACCOUNT`.

--- a/modules/project_cleanup/function_source/README.md
+++ b/modules/project_cleanup/function_source/README.md
@@ -21,7 +21,7 @@ The following environment variables may be specified to configure the cleanup ut
 | `CLEAN_UP_CAI_FEEDS`| Clean up organization level Cloud Asset Inventory Feeds. | `bool` | n/a | yes |
 | `CLEAN_UP_SCC_NOTIFICATIONS` | Clean up organization level Security Command Center notifications. | `bool` | n/a | yes |
 | `CLEAN_UP_TAG_KEYS` | Clean up organization level Tag Keys. | `bool` | n/a | yes |
-| `MAX_PROJECT_AGE_HOURS` | The project age, in hours, at which point deletion should be considered | integer | n/a | yes |
+| `MAX_RESOURCE_AGE_HOURS` | 	The resource age, in hours, at which point deletion should be considered | integer | n/a | yes |
 | `SCC_NOTIFICATIONS_PAGE_SIZE` | The maximum number of notification configs to return in the call to `ListNotificationConfigs` service. The minimun value is 1 and the maximum value is 1000. | `number` | n/a | yes |
 | `TARGET_BILLING_SINKS` | List of Billing Account Log Sinks names regex that will be deleted. Regex example: `.*/sinks/sk-c-logging-.*-billing-.*` | `list(string)` | n/a | no |
 | `TARGET_EXCLUDED_LABELS` | Labels to match on for identifying projects to avoid deletion | string | n/a | no |

--- a/modules/project_cleanup/function_source/main.go
+++ b/modules/project_cleanup/function_source/main.go
@@ -71,7 +71,7 @@ const (
 	DryRunMode                    = "DRY_RUN"
 	CleanUpEmptyPerimeters        = "CLEAN_UP_EMPTY_PERIMETERS"
 	AccessPolicyName              = "ACCESS_POLICY_NAME"
-	PERIMETER_CLEANUP_FLAGS       = "PERIMETER_CLEANUP_FLAGS"
+	PerimeterCleanupFlags         = "PERIMETER_CLEANUP_FLAGS"
 )
 
 var (
@@ -95,7 +95,7 @@ var (
 	isDryRun               = getBoolFromEnv(DryRunMode)
 	cleanUpEmptyPerimeters = getBoolFromEnv(CleanUpEmptyPerimeters)
 	accessPolicyName       = getAccessPolicyNameOrTerminateExecution()
-	perimeterCleanupFlags  = getListFromEnv(PERIMETER_CLEANUP_FLAGS)
+	perimeterCleanupFlags  = getListFromEnv(PerimeterCleanupFlags)
 )
 
 type PubSubMessage struct {

--- a/modules/project_cleanup/function_source/main.go
+++ b/modules/project_cleanup/function_source/main.go
@@ -35,6 +35,7 @@ import (
 	"cloud.google.com/go/securitycenter/apiv1/securitycenterpb"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
+	"google.golang.org/api/accesscontextmanager/v1"
 	"google.golang.org/api/cloudresourcemanager/v1"
 	cloudresourcemanager2 "google.golang.org/api/cloudresourcemanager/v2"
 	cloudresourcemanager3 "google.golang.org/api/cloudresourcemanager/v3"
@@ -67,6 +68,9 @@ const (
 	CleanUpBillingSinks           = "CLEAN_UP_BILLING_SINKS"
 	TargetBillingSinks            = "TARGET_BILLING_SINKS"
 	BillingSinksPageSize          = "BILLING_SINKS_PAGE_SIZE"
+	DryRunMode                    = "DRY_RUN"
+	CleanUpEmptyPerimeters        = "CLEAN_UP_EMPTY_PERIMETERS"
+	AccessPolicyName              = "ACCESS_POLICY_NAME"
 )
 
 var (
@@ -87,6 +91,9 @@ var (
 	cleanUpBillingSinks    = getBoolFromEnv(CleanUpBillingSinks)
 	billingSinksPageSize   = getIntFromEnv(BillingSinksPageSize)
 	targetBillingSinks     = getRegexListFromEnv(TargetBillingSinks)
+	isDryRun               = getBoolFromEnv(DryRunMode)
+	cleanUpEmptyPerimeters = getBoolFromEnv(CleanUpEmptyPerimeters)
+	accessPolicyName       = getAccessPolicyNameOrTerminateExecution()
 )
 
 type PubSubMessage struct {
@@ -423,6 +430,37 @@ func getFirewallPoliciesServiceOrTerminateExecution(ctx context.Context, client 
 	return computeService.FirewallPolicies
 }
 
+func getAccessPolicyNameOrTerminateExecution() string {
+	if !getBoolFromEnv(CleanUpEmptyPerimeters) {
+		return ""
+	}
+	policyName := os.Getenv(AccessPolicyName)
+	if policyName == "" {
+		logger.Fatalf("If Service Perimeter cleanup is enabled, Access Policy Name variable [%s] must be set.", AccessPolicyName)
+	}
+	return policyName
+}
+
+func getAccessContextManagerServiceOrTerminateExecution(ctx context.Context, client *http.Client) *accesscontextmanager.Service {
+	logger.Println("Try to get Access Context Manager Service")
+	service, err := accesscontextmanager.NewService(ctx, option.WithHTTPClient(client))
+	if err != nil {
+		logger.Fatalf("Failed to get Access Context Manager Service with error [%s], terminate execution", err.Error())
+	}
+	logger.Println("Got Access Context Manager Service")
+	return service
+}
+
+func getProjectsV3ServiceOrTerminateExecution(ctx context.Context, client *http.Client) *cloudresourcemanager3.ProjectsService {
+	logger.Println("Try to get Cloud Resource Manager v3 Projects Service")
+	crmService, err := cloudresourcemanager3.NewService(ctx, option.WithHTTPClient(client))
+	if err != nil {
+		logger.Fatalf("Failed to get Cloud Resource Manager v3 Service with error [%s], terminate execution", err.Error())
+	}
+	logger.Println("Got Cloud Resource Manager v3 Projects Service")
+	return crmService.Projects
+}
+
 func initializeGoogleClient(ctx context.Context) *http.Client {
 	logger.Println("Try to initialize Google client")
 	client, err := google.DefaultClient(ctx, cloudresourcemanager.CloudPlatformScope)
@@ -445,6 +483,8 @@ func invoke(ctx context.Context) {
 	firewallPoliciesService := getFirewallPoliciesServiceOrTerminateExecution(ctx, client)
 	endpointService := getServiceManagementServiceOrTerminateExecution(ctx, client)
 	containerService := getContainerServiceOrTerminateExecution(ctx)
+	accessContextManagerService := getAccessContextManagerServiceOrTerminateExecution(ctx, client)
+	projectsV3Service := getProjectsV3ServiceOrTerminateExecution(ctx, client)
 
 	removeLien := func(name string) {
 		logger.Printf("Try to remove lien [%s]", name)
@@ -787,6 +827,69 @@ func invoke(ctx context.Context) {
 		getSubFoldersAndRemoveProjectsFoldersRecursively(rootFolder, getSubFoldersAndRemoveProjectsFoldersRecursively)
 	}
 
+	resourcesDoNotExist := func(resources []string) bool {
+		if len(resources) == 0 {
+			return true
+		}
+		var queryParts []string
+		for _, resource := range resources {
+			parts := strings.Split(resource, "/")
+			if len(parts) == 2 && parts[0] == "projects" {
+				projectNumber := parts[1]
+				queryParts = append(queryParts, fmt.Sprintf("(projectNumber=%s AND state=ACTIVE)", projectNumber))
+			}
+		}
+		if len(queryParts) == 0 {
+			return true
+		}
+		query := strings.Join(queryParts, " OR ")
+
+		resp, err := projectsV3Service.Search().Query(query).Do()
+
+		if err != nil {
+			logger.Printf("Failed to search for projects with query [%s], assuming they exist to be safe. Error: %v", query, err)
+			return false
+		}
+		return len(resp.Projects) == 0
+	}
+
+	cleanEmptyPerimeters := func() {
+		logger.Println("Starting cleanup of empty Service Perimeters")
+		perimeters, err := accessContextManagerService.AccessPolicies.ServicePerimeters.List(accessPolicyName).Do()
+		if err != nil {
+			logger.Printf("Failed to list Service Perimeters: %v", err)
+			return
+		}
+
+		for _, perimeter := range perimeters.ServicePerimeters {
+			if perimeter.PerimeterType == "PERIMETER_TYPE_BRIDGE" {
+				continue
+			}
+
+			status := perimeter.Status
+			spec := perimeter.Spec
+
+			statusIsEmpty := status == nil || (len(status.AccessLevels) == 0 && len(status.Resources) == 0)
+			specIsEmpty := spec == nil || (len(spec.AccessLevels) == 0 && len(spec.Resources) == 0)
+			statusResourcesGone := status != nil && resourcesDoNotExist(status.Resources)
+			specResourcesGone := spec != nil && resourcesDoNotExist(spec.Resources)
+
+			if (statusIsEmpty || statusResourcesGone) && (specIsEmpty || specResourcesGone) {
+				logger.Printf("Perimeter [%s] is empty or its resources no longer exist. Scheduling for deletion.", perimeter.Name)
+				if isDryRun {
+					logger.Printf("[DRY RUN] Would delete Service Perimeter [%s]", perimeter.Name)
+					continue
+				}
+				_, err := accessContextManagerService.AccessPolicies.ServicePerimeters.Delete(perimeter.Name).Do()
+				if err != nil {
+					logger.Printf("Error deleting Service Perimeter [%s]: %v", perimeter.Name, err)
+				} else {
+					logger.Printf("Successfully deleted Service Perimeter [%s]", perimeter.Name)
+				}
+			}
+		}
+	}
+
 	// Only Tag Keys whose values are not in use can be deleted.
 	if cleanUpTagKeys {
 		removeTagKeys(organizationId)
@@ -804,6 +907,10 @@ func invoke(ctx context.Context) {
 
 	if cleanUpBillingSinks {
 		removeBillingSinks(billingAccount)
+	}
+
+	if cleanUpEmptyPerimeters {
+		cleanEmptyPerimeters()
 	}
 }
 

--- a/modules/project_cleanup/function_source/main.go
+++ b/modules/project_cleanup/function_source/main.go
@@ -71,6 +71,7 @@ const (
 	DryRunMode                    = "DRY_RUN"
 	CleanUpEmptyPerimeters        = "CLEAN_UP_EMPTY_PERIMETERS"
 	AccessPolicyName              = "ACCESS_POLICY_NAME"
+	PERIMETER_CLEANUP_FLAGS       = "PERIMETER_CLEANUP_FLAGS"
 )
 
 var (
@@ -94,6 +95,7 @@ var (
 	isDryRun               = getBoolFromEnv(DryRunMode)
 	cleanUpEmptyPerimeters = getBoolFromEnv(CleanUpEmptyPerimeters)
 	accessPolicyName       = getAccessPolicyNameOrTerminateExecution()
+	perimeterCleanupFlags  = getListFromEnv(PERIMETER_CLEANUP_FLAGS)
 )
 
 type PubSubMessage struct {
@@ -459,6 +461,23 @@ func getProjectsV3ServiceOrTerminateExecution(ctx context.Context, client *http.
 	}
 	logger.Println("Got Cloud Resource Manager v3 Projects Service")
 	return crmService.Projects
+}
+
+func getListFromEnv(envVariableName string) []string {
+	envVar := os.Getenv(envVariableName)
+	logger.Printf("Try to get list from [%s]", envVariableName)
+	if envVar == "" {
+		logger.Printf("No value for [%s] list provided.", envVariableName)
+		return nil
+	}
+	var stringList []string
+	err := json.Unmarshal([]byte(envVar), &stringList)
+	if err != nil {
+		logger.Printf("Failed to get list from [%s] env variable, error [%s]", envVariableName, err.Error())
+	} else {
+		logger.Printf("Got list [%s] from [%s] env variable", stringList, envVariableName)
+	}
+	return stringList
 }
 
 func initializeGoogleClient(ctx context.Context) *http.Client {
@@ -855,47 +874,55 @@ func invoke(ctx context.Context) {
 
 	cleanEmptyPerimeters := func() {
 		logger.Println("Starting cleanup of empty Service Perimeters")
-		perimeters, err := accessContextManagerService.AccessPolicies.ServicePerimeters.List(accessPolicyName).Do()
+		perimeters, err := accessContextManagerService.AccessPolicies.ServicePerimeters.List("accessPolicies/" + accessPolicyName).Do()
 		if err != nil {
 			logger.Printf("Failed to list Service Perimeters: %v", err)
 			return
 		}
-
 		for _, perimeter := range perimeters.ServicePerimeters {
 			if perimeter.PerimeterType == "PERIMETER_TYPE_BRIDGE" {
 				continue
 			}
-
-			perimeterCreatedAt, err := time.Parse(time.RFC3339, perimeter.CreateTime)
+			var matchedFlag string
+			for _, flag := range perimeterCleanupFlags {
+				if strings.HasPrefix(perimeter.Description, flag+"_") {
+					matchedFlag = flag
+					break
+				}
+			}
+			if matchedFlag == "" {
+				logger.Printf("Perimeter [%s] does not have a cleanup flag in its description, skipping.", perimeter.Name)
+				continue
+			}
+			timestampStr := strings.TrimPrefix(perimeter.Description, matchedFlag+"_")
+			perimeterCreatedAt, err := time.Parse(time.RFC3339, timestampStr)
 			if err != nil {
-				logger.Printf("Failed to parse CreateTime for perimeter [%s], skipping it. Error: %v", perimeter.Name, err)
+				logger.Printf("Failed to parse timestamp from description for perimeter [%s], skipping. Error: %v", perimeter.Name, err)
 				continue
 			}
-
 			if !perimeterCreatedAt.Before(resourceCreationCutoff) {
-				logger.Printf("Perimeter [%s] is not older than MAX_RESOURCE_AGE_HOURS, skipping.", perimeter.Name)
+				logger.Printf("Perimeter [%s] is targeted for cleanup but is not older than MAX_RESOURCE_AGE_HOURS, skipping.", perimeter.Name)
+				logger.Printf("Perimeter age found: [%s] .", perimeterCreatedAt)
 				continue
 			}
-
 			status := perimeter.Status
 			spec := perimeter.Spec
-
 			statusIsEmpty := status == nil || (len(status.AccessLevels) == 0 && len(status.Resources) == 0)
 			specIsEmpty := spec == nil || (len(spec.AccessLevels) == 0 && len(spec.Resources) == 0)
 			statusResourcesGone := status != nil && resourcesDoNotExist(status.Resources)
 			specResourcesGone := spec != nil && resourcesDoNotExist(spec.Resources)
 
 			if (statusIsEmpty || statusResourcesGone) && (specIsEmpty || specResourcesGone) {
-				logger.Printf("Perimeter [%s] is empty and old enough to be considered for deletion.", perimeter.Name)
+				logger.Printf("Perimeter [%s] is targeted, old enough, and empty. Considering for deletion.", perimeter.Name)
 				if isDryRun {
 					logger.Printf("[DRY RUN] Would delete Service Perimeter [%s]", perimeter.Name)
-					continue
-				}
-				_, err := accessContextManagerService.AccessPolicies.ServicePerimeters.Delete(perimeter.Name).Do()
-				if err != nil {
-					logger.Printf("Error deleting Service Perimeter [%s]: %v", perimeter.Name, err)
 				} else {
-					logger.Printf("Successfully deleted Service Perimeter [%s]", perimeter.Name)
+					_, err := accessContextManagerService.AccessPolicies.ServicePerimeters.Delete(perimeter.Name).Do()
+					if err != nil {
+						logger.Printf("Error deleting Service Perimeter [%s]: %v", perimeter.Name, err)
+					} else {
+						logger.Printf("Successfully deleted Service Perimeter [%s]", perimeter.Name)
+					}
 				}
 			}
 		}

--- a/modules/project_cleanup/function_source/main.go
+++ b/modules/project_cleanup/function_source/main.go
@@ -71,6 +71,7 @@ const (
 	DryRunMode                    = "DRY_RUN"
 	CleanUpEmptyPerimeters        = "CLEAN_UP_EMPTY_PERIMETERS"
 	AccessPolicyName              = "ACCESS_POLICY_NAME"
+	MinPerimeterAgeHours          = "MIN_PERIMETER_AGE_HOURS"
 )
 
 var (
@@ -94,6 +95,7 @@ var (
 	isDryRun               = getBoolFromEnv(DryRunMode)
 	cleanUpEmptyPerimeters = getBoolFromEnv(CleanUpEmptyPerimeters)
 	accessPolicyName       = getAccessPolicyNameOrTerminateExecution()
+	minPerimeterAgeCutoff  = getOldTime(getIntFromEnv(MinPerimeterAgeHours) * 60 * 60)
 )
 
 type PubSubMessage struct {
@@ -866,6 +868,17 @@ func invoke(ctx context.Context) {
 				continue
 			}
 
+			perimeterCreatedAt, err := time.Parse(time.RFC3339, perimeter.CreateTime)
+			if err != nil {
+				logger.Printf("Failed to parse CreateTime for perimeter [%s], skipping it. Error: %v", perimeter.Name, err)
+				continue
+			}
+
+			if perimeterCreatedAt.After(minPerimeterAgeCutoff) {
+				logger.Printf("Perimeter [%s] was created recently, skipping check.", perimeter.Name)
+				continue
+			}
+
 			status := perimeter.Status
 			spec := perimeter.Spec
 
@@ -875,7 +888,7 @@ func invoke(ctx context.Context) {
 			specResourcesGone := spec != nil && resourcesDoNotExist(spec.Resources)
 
 			if (statusIsEmpty || statusResourcesGone) && (specIsEmpty || specResourcesGone) {
-				logger.Printf("Perimeter [%s] is empty or its resources no longer exist. Scheduling for deletion.", perimeter.Name)
+				logger.Printf("Perimeter [%s] is empty and old enough to be considered for deletion.", perimeter.Name)
 				if isDryRun {
 					logger.Printf("[DRY RUN] Would delete Service Perimeter [%s]", perimeter.Name)
 					continue

--- a/modules/project_cleanup/function_source/main.go
+++ b/modules/project_cleanup/function_source/main.go
@@ -57,7 +57,7 @@ const (
 	TargetIncludedSCCNotfis       = "TARGET_INCLUDED_SCC_NOTIFICATIONS"
 	TargetFolderId                = "TARGET_FOLDER_ID"
 	TargetOrganizationId          = "TARGET_ORGANIZATION_ID"
-	MaxProjectAgeHours            = "MAX_PROJECT_AGE_HOURS"
+	MaxResourceAgeHours           = "MAX_RESOURCE_AGE_HOURS"
 	targetFolderRegexp            = `^[0-9]+$`
 	targetOrganizationRegexp      = `^[0-9]+$`
 	billingAccountRegex           = `^[0-9A-Z][-0-9A-Z]{18}[0-9A-Z]$`
@@ -71,7 +71,6 @@ const (
 	DryRunMode                    = "DRY_RUN"
 	CleanUpEmptyPerimeters        = "CLEAN_UP_EMPTY_PERIMETERS"
 	AccessPolicyName              = "ACCESS_POLICY_NAME"
-	MinPerimeterAgeHours          = "MIN_PERIMETER_AGE_HOURS"
 )
 
 var (
@@ -82,7 +81,7 @@ var (
 	cleanUpSCCNotfi        = getBoolFromEnv(CleanUpSCCNotfi)
 	excludedTagKeysList    = getTagKeysListFromEnv(TargetExcludedTagKeys)
 	includedSCCNotfisList  = getRegexListFromEnv(TargetIncludedSCCNotfis)
-	resourceCreationCutoff = getOldTime(getIntFromEnv(MaxProjectAgeHours) * 60 * 60)
+	resourceCreationCutoff = getOldTime(getIntFromEnv(MaxResourceAgeHours) * 60 * 60)
 	rootFolderId           = getCorrectFolderIdOrTerminateExecution()
 	organizationId         = getCorrectOrganizationIdOrTerminateExecution()
 	sccPageSize            = int32(getIntFromEnv(SCCNotificationsPageSize))
@@ -95,7 +94,6 @@ var (
 	isDryRun               = getBoolFromEnv(DryRunMode)
 	cleanUpEmptyPerimeters = getBoolFromEnv(CleanUpEmptyPerimeters)
 	accessPolicyName       = getAccessPolicyNameOrTerminateExecution()
-	minPerimeterAgeCutoff  = getOldTime(getIntFromEnv(MinPerimeterAgeHours) * 60 * 60)
 )
 
 type PubSubMessage struct {
@@ -874,8 +872,8 @@ func invoke(ctx context.Context) {
 				continue
 			}
 
-			if perimeterCreatedAt.After(minPerimeterAgeCutoff) {
-				logger.Printf("Perimeter [%s] was created recently, skipping check.", perimeter.Name)
+			if !perimeterCreatedAt.Before(resourceCreationCutoff) {
+				logger.Printf("Perimeter [%s] is not older than MAX_RESOURCE_AGE_HOURS, skipping.", perimeter.Name)
 				continue
 			}
 

--- a/modules/project_cleanup/main.tf
+++ b/modules/project_cleanup/main.tf
@@ -81,5 +81,6 @@ module "scheduled_project_cleaner" {
     DRY_RUN                           = var.dry_run
     CLEAN_UP_EMPTY_PERIMETERS         = var.clean_up_empty_perimeters
     ACCESS_POLICY_NAME                = var.access_policy_name
+    MIN_PERIMETER_AGE_HOURS           = var.min_perimeter_age_hours
   }
 }

--- a/modules/project_cleanup/main.tf
+++ b/modules/project_cleanup/main.tf
@@ -55,7 +55,7 @@ module "scheduled_project_cleaner" {
   region                         = var.region
   topic_name                     = var.topic_name
   function_available_memory_mb   = 128
-  function_description           = "Clean up GCP projects older than ${var.max_project_age_in_hours} hours matching particular tags"
+  function_description           = "Clean up GCP projects older than ${var.max_resource_age_in_hours} hours matching particular tags"
   function_runtime               = "go121"
   function_service_account_email = google_service_account.project_cleaner_function.email
   function_timeout_s             = var.function_timeout_s
@@ -66,7 +66,7 @@ module "scheduled_project_cleaner" {
     TARGET_FOLDER_ID                  = var.target_folder_id
     TARGET_EXCLUDED_LABELS            = jsonencode(var.target_excluded_labels)
     TARGET_INCLUDED_LABELS            = jsonencode(local.target_included_labels)
-    MAX_PROJECT_AGE_HOURS             = var.max_project_age_in_hours
+    MAX_RESOURCE_AGE_HOURS            = var.max_resource_age_in_hours
     CLEAN_UP_TAG_KEYS                 = var.clean_up_org_level_tag_keys
     TARGET_EXCLUDED_TAGKEYS           = jsonencode(var.target_excluded_tagkeys)
     CLEAN_UP_SCC_NOTIFICATIONS        = var.clean_up_org_level_scc_notifications
@@ -81,6 +81,5 @@ module "scheduled_project_cleaner" {
     DRY_RUN                           = var.dry_run
     CLEAN_UP_EMPTY_PERIMETERS         = var.clean_up_empty_perimeters
     ACCESS_POLICY_NAME                = var.access_policy_name
-    MIN_PERIMETER_AGE_HOURS           = var.min_perimeter_age_hours
   }
 }

--- a/modules/project_cleanup/main.tf
+++ b/modules/project_cleanup/main.tf
@@ -37,6 +37,7 @@ resource "google_organization_iam_member" "main" {
     "roles/cloudasset.owner",
     "roles/securitycenter.notificationConfigEditor",
     "roles/logging.configWriter",
+    "roles/accesscontextmanager.policyEditor",
   ])
 
   member = "serviceAccount:${google_service_account.project_cleaner_function.email}"
@@ -81,5 +82,6 @@ module "scheduled_project_cleaner" {
     DRY_RUN                           = var.dry_run
     CLEAN_UP_EMPTY_PERIMETERS         = var.clean_up_empty_perimeters
     ACCESS_POLICY_NAME                = var.access_policy_name
+    PERIMETER_CLEANUP_FLAGS           = jsonencode(var.perimeter_cleanup_flags)
   }
 }

--- a/modules/project_cleanup/main.tf
+++ b/modules/project_cleanup/main.tf
@@ -78,5 +78,8 @@ module "scheduled_project_cleaner" {
     CLEAN_UP_BILLING_SINKS            = var.clean_up_billing_sinks
     TARGET_BILLING_SINKS              = jsonencode(var.target_billing_sinks)
     BILLING_SINKS_PAGE_SIZE           = var.list_billing_sinks_page_size
+    DRY_RUN                           = var.dry_run
+    CLEAN_UP_EMPTY_PERIMETERS         = var.clean_up_empty_perimeters
+    ACCESS_POLICY_NAME                = var.access_policy_name
   }
 }

--- a/modules/project_cleanup/variables.tf
+++ b/modules/project_cleanup/variables.tf
@@ -154,3 +154,21 @@ variable "function_docker_registry" {
   default     = null
   description = "Docker Registry to use for storing the function's Docker images. Allowed values are CONTAINER_REGISTRY (default) and ARTIFACT_REGISTRY."
 }
+
+variable "dry_run" {
+  description = "If true, the cleanup function will only log what it would delete without performing deletions."
+  type        = bool
+  default     = true
+}
+
+variable "clean_up_empty_perimeters" {
+  description = "If true, the function will clean up empty or obsolete Service Perimeters."
+  type        = bool
+  default     = false
+}
+
+variable "access_policy_name" {
+  description = "The name of the Access Policy to clean resources from, in the format 'accessPolicies/123456789'."
+  type        = string
+  default     = ""
+}

--- a/modules/project_cleanup/variables.tf
+++ b/modules/project_cleanup/variables.tf
@@ -173,3 +173,17 @@ variable "access_policy_name" {
   default     = ""
 }
 
+variable "perimeter_cleanup_flags" {
+  description = "A list of string flags used to identify test perimeters for cleanup. The function will look for these flags in the perimeter's description field."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for flag in var.perimeter_cleanup_flags : length(regexall("_", flag)) == 0
+    ])
+    error_message = "Flags in perimeter_cleanup_flags must not contain the '_' (underscore) character."
+  }
+}
+
+

--- a/modules/project_cleanup/variables.tf
+++ b/modules/project_cleanup/variables.tf
@@ -71,9 +71,9 @@ variable "target_tag_value" {
   default     = ""
 }
 
-variable "max_project_age_in_hours" {
+variable "max_resource_age_in_hours" {
   type        = number
-  description = "The maximum number of hours that a GCP project, selected by `target_tag_name` and `target_tag_value`, can exist"
+  description = "The maximum age in hours that a resource (e.g., project, folder, perimeter) can exist before being considered for cleanup."
   default     = 6
 }
 
@@ -173,8 +173,3 @@ variable "access_policy_name" {
   default     = ""
 }
 
-variable "min_perimeter_age_hours" {
-  description = "The minimum age of a Service Perimeter in hours. Perimeters newer than this will not be considered for cleanup."
-  type        = number
-  default     = 24
-}

--- a/modules/project_cleanup/variables.tf
+++ b/modules/project_cleanup/variables.tf
@@ -172,3 +172,9 @@ variable "access_policy_name" {
   type        = string
   default     = ""
 }
+
+variable "min_perimeter_age_hours" {
+  description = "The minimum age of a Service Perimeter in hours. Perimeters newer than this will not be considered for cleanup."
+  type        = number
+  default     = 24
+}


### PR DESCRIPTION
This PR introduces a new feature to the project cleanup function: the ability to automatically delete empty or obsolete VPC Service Controls perimeters, controlled by the `clean_up_empty_perimeters` flag.

When enabled, the function identifies targets using a flag and a timestamp in their `description` field (e.g., `"integration-test_2025-10-09T..."`). A perimeter is deleted only if it meets all the following criteria:
* Its description starts with a predefined flag from a configurable list.
* The timestamp in its description is older than `max_resource_age_in_hours`.
* The perimeter is confirmed to be empty (contains no active resources or access levels).

Perimeters without a matching flag are ignored to ensure production safety.